### PR TITLE
Feat/implement core schema migration infrastructure

### DIFF
--- a/assets/sql/migrations/001_init_core_schema.sql
+++ b/assets/sql/migrations/001_init_core_schema.sql
@@ -1,0 +1,5 @@
+-- 001_init_core_schema.sql
+-- Initial migration for the core schema migration system.
+-- This migration is intentionally a no-op; later migrations will
+-- introduce actual tables and indices.
+

--- a/docs/storage_conventions.md
+++ b/docs/storage_conventions.md
@@ -95,3 +95,22 @@ Any new foreign keys introduced in later phases should explicitly choose between
 
 The rationale for non‑obvious choices should be captured either here or in an Architecture Decision Record under `docs/decisions/`.
 
+---
+
+### 6. Migration Files & Versioning
+
+- **Migration metadata table**
+  - A dedicated `schema_migrations` table tracks which migrations have been applied:
+    - `id` – `INTEGER PRIMARY KEY AUTOINCREMENT`
+    - `name` – `TEXT NOT NULL` (e.g., `001_init_core_schema`)
+    - `applied_at` – `INTEGER NOT NULL` (Unix epoch milliseconds in UTC)
+- **Storage location**
+  - Migration definitions are stored as `.sql` files under `assets/sql/migrations/`.
+  - Filenames start with a zero‑padded numeric prefix followed by a descriptive name, e.g.:
+    - `001_init_core_schema.sql`
+    - `002_add_documents_and_pages.sql`
+- **Ordering & idempotence**
+  - Migrations are applied in **lexicographical filename order**, which matches numeric prefix order.
+  - Each migration is applied at most once; applied migrations are recorded in `schema_migrations` by `name`.
+  - Migration runners must assume foreign keys are enabled and wrap each migration in a transaction.
+

--- a/lib/infrastructure/sqlite/migrations/migration.dart
+++ b/lib/infrastructure/sqlite/migrations/migration.dart
@@ -1,0 +1,24 @@
+/// Represents a single database schema migration.
+///
+/// - [name] is a stable identifier such as `001_init_core_schema`.
+/// - [sql] contains the SQL to apply for this migration.
+class Migration {
+  final String name;
+  final String sql;
+
+  const Migration({
+    required this.name,
+    required this.sql,
+  });
+}
+
+/// Returns a new list of [Migration]s sorted by their [name].
+///
+/// File-based migrations use zero-padded numeric prefixes in the name,
+/// so lexicographical ordering matches chronological ordering.
+List<Migration> sortMigrationsByName(Iterable<Migration> migrations) {
+  final sorted = List<Migration>.from(migrations);
+  sorted.sort((a, b) => a.name.compareTo(b.name));
+  return sorted;
+}
+

--- a/lib/infrastructure/sqlite/migrations/run_migrations.dart
+++ b/lib/infrastructure/sqlite/migrations/run_migrations.dart
@@ -1,0 +1,23 @@
+import 'migration.dart';
+import 'migration_runner.dart';
+
+typedef MigrationLoader = Future<List<Migration>> Function();
+
+/// Convenience entrypoint for running all migrations against a database.
+///
+/// This is the function that application startup code or a dedicated
+/// CLI/test harness should call once it has constructed a [MigrationDb]
+/// implementation and a [MigrationLoader] that discovers available
+/// migrations (for example from `assets/sql/migrations/`).
+Future<void> runMigrations({
+  required MigrationDb db,
+  required MigrationLoader loadMigrations,
+}) async {
+  final runner = MigrationRunner(
+    db: db,
+    loadMigrations: loadMigrations,
+  );
+
+  await runner.runAll();
+}
+

--- a/lib/infrastructure/sqlite/migrations/schema_migrations_table.dart
+++ b/lib/infrastructure/sqlite/migrations/schema_migrations_table.dart
@@ -1,0 +1,17 @@
+/// SQL definition for the `schema_migrations` metadata table.
+///
+/// This table tracks which migrations have been applied.
+/// - `id`: auto-incremented integer primary key.
+/// - `name`: stable migration identifier (e.g. `001_init_core_schema`).
+/// - `applied_at`: Unix epoch milliseconds in UTC.
+const String createSchemaMigrationsTableSql = '''
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  applied_at INTEGER NOT NULL
+);
+''';
+
+/// Example of the expected migration name format.
+const String exampleMigrationName = '001_init_core_schema';
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,42 +29,58 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.7"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -101,19 +117,51 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  glob:
+    dependency: transitive
+    description:
+      name: glob
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "7a08a0d684cb3b8fb604b78455d5d352f502b68079f7b80b831c62220ab0a4f6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   integration_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      name: leak_tracker
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "11.0.2"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.10"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -122,38 +170,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.17.0"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: "89e83885ba09da5fdf2cdacc8002a712ca238c28b7f717910b34bcd27b0d03ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.4"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   platform:
     dependency: transitive
     description:
@@ -170,11 +234,19 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
+  pub_semver:
+    dependency: transitive
+    description:
+      name: pub_semver
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -183,22 +255,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  sqlite3:
+    dependency: "direct main"
+    description:
+      name: sqlite3
+      sha256: b7cf6b37667f6a921281797d2499ffc60fb878b161058d422064f0ddc78f6aa6
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -227,34 +307,42 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "15.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   webdriver:
     dependency: transitive
     description:
@@ -263,5 +351,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  yaml:
+    dependency: transitive
+    description:
+      name: yaml
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
 sdks:
-  dart: ">=2.19.4 <3.0.0"
+  dart: ">=3.9.999 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  sqlite3: ^3.1.6
+  
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,3 +23,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/sql/migrations/

--- a/test/infrastructure/sqlite/migrations/migration_runner_test.dart
+++ b/test/infrastructure/sqlite/migrations/migration_runner_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+class Sqlite3MigrationDb implements MigrationDb {
+  Sqlite3MigrationDb(this._db);
+
+  final sqlite.Database _db;
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) async {
+    _db.execute(sql, parameters);
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> query(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = _db.select(sql, parameters);
+    return result
+        .map<Map<String, Object?>>((row) => Map<String, Object?>.from(row))
+        .toList();
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function() action) async {
+    _db.execute('BEGIN');
+    try {
+      final result = await action();
+      _db.execute('COMMIT');
+      return result;
+    } catch (e) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
+  }
+}
+
+void main() {
+  group('MigrationRunner', () {
+    test('creates schema_migrations and records applied migrations', () async {
+      final db = Sqlite3MigrationDb(sqlite.sqlite3.openInMemory());
+
+      final migrations = <Migration>[
+        const Migration(
+          name: '001_init_core_schema',
+          sql: '',
+        ),
+      ];
+
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: () async => migrations,
+      );
+
+      await runner.runAll();
+
+      // schema_migrations table exists
+      final pragmaResult = await db.query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'schema_migrations'",
+      );
+      expect(pragmaResult, isNotEmpty);
+
+      // all known migrations are recorded as applied
+      final appliedRows = await db.query(
+        'SELECT name FROM schema_migrations',
+      );
+      final appliedNames = appliedRows
+          .map((row) => row['name'])
+          .whereType<String>()
+          .toSet();
+
+      expect(appliedNames, contains('001_init_core_schema'));
+    });
+  });
+}
+


### PR DESCRIPTION
## What changed

Adds SQLite migration infrastructure so schema changes are versioned and applied in order. Includes:

- **Metadata table** `schema_migrations` to record applied migrations
- **Migration abstraction** (name + SQL) with deterministic ordering from `.sql` files
- **Migration runner** that ensures the metadata table exists, runs pending migrations in a transaction, and records each applied migration (idempotent re-runs)
- **Wiring** so migrations run on app/CLI startup (or via a dedicated path)
- **Initial migration** `001_init_core_schema` as first real migration
- **Tests** for a fresh DB run and for idempotent re-run
- **Docs** for storage layout and how the runner is invoked

## Why

We need a single, repeatable way to bring any database (dev, CI, or future installs) up to the current schema without manual SQL. This sets that up and keeps it boring and predictable.

## How to test

1. From project root, run tests: `dart test test/infrastructure/sqlite/migrations/`
2. (Optional) Run the app or CLI so migrations execute on a real DB and confirm `schema_migrations` contains the expected rows.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (including ADRs if applicable)
- [x] Linter/Formatter passes
- [x] No debug logs or "TODOs" left in code