### PR TITLE
Feat/create tables for summaries keywords documentkeyword relations and places

### DIFF
--- a/assets/sql/migrations/003_add_summaries.sql
+++ b/assets/sql/migrations/003_add_summaries.sql
@@ -1,0 +1,10 @@
+-- 003_add_summaries.sql
+-- Add summaries table (1:1 with documents).
+
+CREATE TABLE summaries (
+  document_id TEXT PRIMARY KEY,
+  text TEXT NOT NULL,
+  model_version TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
+);

--- a/assets/sql/migrations/004_add_keywords.sql
+++ b/assets/sql/migrations/004_add_keywords.sql
@@ -1,0 +1,14 @@
+-- 004_add_keywords.sql
+-- Add keywords table with unique (value, type) and indices.
+
+CREATE TABLE keywords (
+  id TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  type TEXT NOT NULL,
+  global_frequency INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  UNIQUE (value, type)
+);
+
+CREATE INDEX idx_keywords_value ON keywords(value);
+CREATE INDEX idx_keywords_type ON keywords(type);

--- a/assets/sql/migrations/005_add_document_keywords.sql
+++ b/assets/sql/migrations/005_add_document_keywords.sql
@@ -1,0 +1,17 @@
+-- 005_add_document_keywords.sql
+-- Add document_keywords join table (many-to-many documents <-> keywords).
+
+CREATE TABLE document_keywords (
+  id TEXT PRIMARY KEY,
+  document_id TEXT NOT NULL,
+  keyword_id TEXT NOT NULL,
+  weight REAL NOT NULL,
+  confidence REAL NOT NULL,
+  source TEXT,
+  FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE,
+  FOREIGN KEY (keyword_id) REFERENCES keywords(id) ON DELETE CASCADE,
+  UNIQUE (document_id, keyword_id)
+);
+
+CREATE INDEX idx_document_keywords_document_id ON document_keywords(document_id);
+CREATE INDEX idx_document_keywords_keyword_id ON document_keywords(keyword_id);

--- a/docs/storage_conventions.md
+++ b/docs/storage_conventions.md
@@ -109,6 +109,9 @@ The rationale for non‑obvious choices should be captured either here or in an 
   - Filenames start with a zero‑padded numeric prefix followed by a descriptive name, e.g.:
     - `001_init_core_schema.sql`
     - `002_add_documents_and_pages.sql`
+    - `003_add_summaries.sql`
+    - `004_add_keywords.sql`
+    - `005_add_document_keywords.sql`
 - **Ordering & idempotence**
   - Migrations are applied in **lexicographical filename order**, which matches numeric prefix order.
   - Each migration is applied at most once; applied migrations are recorded in `schema_migrations` by `name`.
@@ -121,4 +124,12 @@ The rationale for non‑obvious choices should be captured either here or in an 
     - `documents`: `id`, `title`, `file_path`, `status`, `confidence_score`, `place_id` (FK → `places.id` ON DELETE RESTRICT), `created_at`, `updated_at`.
     - `pages`: `id`, `document_id` (FK → `documents.id` ON DELETE CASCADE), `page_number`, `raw_text`, `processed_text`, `ocr_confidence`; UNIQUE `(document_id, page_number)`.
     - Indices: `idx_documents_status`, `idx_documents_place_id`, `idx_documents_created_at_status`, `idx_pages_document_id`.
+  - **`003_add_summaries.sql`** – Creates:
+    - `summaries`: `document_id` (PK, FK → `documents.id` ON DELETE CASCADE), `text`, `model_version`, `created_at` (1:1 with documents).
+  - **`004_add_keywords.sql`** – Creates:
+    - `keywords`: `id`, `value`, `type`, `global_frequency` (DEFAULT 0), `created_at`; UNIQUE `(value, type)`.
+    - Indices: `idx_keywords_value`, `idx_keywords_type`.
+  - **`005_add_document_keywords.sql`** – Creates:
+    - `document_keywords`: `id`, `document_id` (FK → `documents.id` ON DELETE CASCADE), `keyword_id` (FK → `keywords.id` ON DELETE CASCADE), `weight`, `confidence`, `source` (optional); UNIQUE `(document_id, keyword_id)`.
+    - Indices: `idx_document_keywords_document_id`, `idx_document_keywords_keyword_id`.
 

--- a/test/infrastructure/sqlite/migrations/migration_runner_test.dart
+++ b/test/infrastructure/sqlite/migrations/migration_runner_test.dart
@@ -49,6 +49,8 @@ Future<List<Migration>> _loadTestMigrations() async {
       await rootBundle.loadString('assets/sql/migrations/002_add_documents_and_pages.sql');
   final summariesSql =
       await rootBundle.loadString('assets/sql/migrations/003_add_summaries.sql');
+  final keywordsSql =
+      await rootBundle.loadString('assets/sql/migrations/004_add_keywords.sql');
 
   return <Migration>[
     Migration(
@@ -62,6 +64,10 @@ Future<List<Migration>> _loadTestMigrations() async {
     Migration(
       name: '003_add_summaries',
       sql: summariesSql,
+    ),
+    Migration(
+      name: '004_add_keywords',
+      sql: keywordsSql,
     ),
   ];
 }

--- a/test/infrastructure/sqlite/migrations/migration_runner_test.dart
+++ b/test/infrastructure/sqlite/migrations/migration_runner_test.dart
@@ -51,6 +51,8 @@ Future<List<Migration>> _loadTestMigrations() async {
       await rootBundle.loadString('assets/sql/migrations/003_add_summaries.sql');
   final keywordsSql =
       await rootBundle.loadString('assets/sql/migrations/004_add_keywords.sql');
+  final documentKeywordsSql = await rootBundle.loadString(
+      'assets/sql/migrations/005_add_document_keywords.sql');
 
   return <Migration>[
     Migration(
@@ -68,6 +70,10 @@ Future<List<Migration>> _loadTestMigrations() async {
     Migration(
       name: '004_add_keywords',
       sql: keywordsSql,
+    ),
+    Migration(
+      name: '005_add_document_keywords',
+      sql: documentKeywordsSql,
     ),
   ];
 }

--- a/test/infrastructure/sqlite/migrations/migration_runner_test.dart
+++ b/test/infrastructure/sqlite/migrations/migration_runner_test.dart
@@ -262,6 +262,127 @@ INSERT INTO pages (
       );
       expect(remainingPages, isEmpty);
     });
+
+    test('supports summaries, keywords, and document_keywords with referential integrity',
+        () async {
+      final db = Sqlite3MigrationDb(sqlite.sqlite3.openInMemory());
+
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+
+      await runner.runAll();
+
+      const now = 1000;
+
+      // Insert a place and a document.
+      await db.execute(
+        '''
+INSERT INTO places (id, name, description, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?)
+''',
+        ['place-1', 'Archive', null, now, now],
+      );
+
+      await db.execute(
+        '''
+INSERT INTO documents (
+  id, title, file_path, status, confidence_score, place_id, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+''',
+        ['doc-1', 'Test Doc', '/path/doc.pdf', 'completed', 0.9, 'place-1', now, now],
+      );
+
+      // Insert summary (1:1 with document).
+      await db.execute(
+        '''
+INSERT INTO summaries (document_id, text, model_version, created_at)
+VALUES (?, ?, ?, ?)
+''',
+        ['doc-1', 'A short summary.', 'qwen2.5-0.5b', now],
+      );
+
+      // Insert keywords.
+      await db.execute(
+        '''
+INSERT INTO keywords (id, value, type, global_frequency, created_at)
+VALUES (?, ?, ?, ?, ?)
+''',
+        ['kw-1', 'tax', 'topic', 0, now],
+      );
+      await db.execute(
+        '''
+INSERT INTO keywords (id, value, type, global_frequency, created_at)
+VALUES (?, ?, ?, ?, ?)
+''',
+        ['kw-2', '2024', 'date', 0, now],
+      );
+
+      // Link document to keywords via document_keywords.
+      await db.execute(
+        '''
+INSERT INTO document_keywords (id, document_id, keyword_id, weight, confidence, source)
+VALUES (?, ?, ?, ?, ?, ?)
+''',
+        ['dk-1', 'doc-1', 'kw-1', 0.8, 0.9, 'llm_initial'],
+      );
+      await db.execute(
+        '''
+INSERT INTO document_keywords (id, document_id, keyword_id, weight, confidence, source)
+VALUES (?, ?, ?, ?, ?, ?)
+''',
+        ['dk-2', 'doc-1', 'kw-2', 0.5, 0.85, null],
+      );
+
+      // Query back and verify.
+      final summaries = await db.query(
+        'SELECT * FROM summaries WHERE document_id = ?',
+        ['doc-1'],
+      );
+      expect(summaries, hasLength(1));
+      expect(summaries.single['text'], 'A short summary.');
+      expect(summaries.single['model_version'], 'qwen2.5-0.5b');
+
+      final keywords = await db.query('SELECT * FROM keywords ORDER BY id', const []);
+      expect(keywords, hasLength(2));
+
+      final docKeywords = await db.query(
+        'SELECT * FROM document_keywords WHERE document_id = ? ORDER BY keyword_id',
+        ['doc-1'],
+      );
+      expect(docKeywords, hasLength(2));
+      expect(docKeywords.first['weight'], 0.8);
+      expect(docKeywords.first['confidence'], 0.9);
+
+      // Unique (document_id, keyword_id) rejects duplicate.
+      await expectLater(
+        db.execute(
+          '''
+INSERT INTO document_keywords (id, document_id, keyword_id, weight, confidence)
+VALUES (?, ?, ?, ?, ?)
+''',
+          ['dk-dup', 'doc-1', 'kw-1', 0.1, 0.1],
+        ),
+        throwsA(isA<sqlite.SqliteException>()),
+      );
+
+      // Deleting document cascades to summaries and document_keywords.
+      await db.execute('DELETE FROM documents WHERE id = ?', ['doc-1']);
+
+      final summariesAfter = await db.query('SELECT * FROM summaries', const []);
+      expect(summariesAfter, isEmpty);
+
+      final docKeywordsAfter = await db.query(
+        'SELECT * FROM document_keywords WHERE document_id = ?',
+        ['doc-1'],
+      );
+      expect(docKeywordsAfter, isEmpty);
+
+      // Keywords remain (reusable).
+      final keywordsAfter = await db.query('SELECT * FROM keywords', const []);
+      expect(keywordsAfter, hasLength(2));
+    });
   });
 }
 

--- a/test/infrastructure/sqlite/migrations/migration_runner_test.dart
+++ b/test/infrastructure/sqlite/migrations/migration_runner_test.dart
@@ -47,6 +47,8 @@ Future<List<Migration>> _loadTestMigrations() async {
       await rootBundle.loadString('assets/sql/migrations/001_init_core_schema.sql');
   final documentsAndPagesSql =
       await rootBundle.loadString('assets/sql/migrations/002_add_documents_and_pages.sql');
+  final summariesSql =
+      await rootBundle.loadString('assets/sql/migrations/003_add_summaries.sql');
 
   return <Migration>[
     Migration(
@@ -56,6 +58,10 @@ Future<List<Migration>> _loadTestMigrations() async {
     Migration(
       name: '002_add_documents_and_pages',
       sql: documentsAndPagesSql,
+    ),
+    Migration(
+      name: '003_add_summaries',
+      sql: summariesSql,
     ),
   ];
 }


### PR DESCRIPTION
## What changed

- Added three migrations: `summaries` (1:1 with documents), `keywords` (unique by value+type), and `document_keywords` (join table with weight/confidence).
- Wired 003–005 into the test migration loader and added an integration test that inserts Place → Document → Summary + Keywords + document_keywords, then checks uniqueness and cascade deletes.
- Updated `docs/storage_conventions.md` to list 003–005 and their schema details.

## Why

Phase 1 needs a single source of truth for summaries, keywords, and document–keyword relations. These tables were specified in the data model but missing from the schema; they’re required before the pipeline can persist LLM output.

## How to test

1. `flutter test test/infrastructure/sqlite/migrations/migration_runner_test.dart` — all 5 tests should pass (including the new “summaries, keywords, document_keywords with referential integrity” test).
2. Skim `assets/sql/migrations/003_add_summaries.sql`, `004_add_keywords.sql`, `005_add_document_keywords.sql` and `docs/storage_conventions.md` for consistency.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Linter/Formatter passes
- [x] No debug logs or TODOs left in code