### PR TITLE
Docs/define and document sqlite fts5 design

### DIFF
--- a/docs/decisions/0011-sqlite-fts5-design.md
+++ b/docs/decisions/0011-sqlite-fts5-design.md
@@ -1,0 +1,43 @@
+# SQLite FTS5 full-text search design
+
+Date: 2026-02-19
+
+Status: Accepted
+
+## Context
+
+The project needs full-text search over documents using SQLite FTS5. We must decide the indexing level (document vs page), which fields to index, and how to keep the FTS table(s) in sync with the base tables. Without a clear design, search features risk inconsistency or inefficiency.
+
+## Decision
+
+### Indexing level: document-level
+
+We use **document-level** indexing: one FTS row per document. Page-level indexing (one row per page) is not used in Phase 1.
+
+**Rationale:** Document-level matches the primary use case (“find documents that match this text”) and keeps the schema simple. A single `documents_fts` table is easier to reason about and to sync. Page-level indexing can be added later if we need “jump to page” or per-page search.
+
+### Schema: single FTS table `documents_fts`
+
+One FTS5 virtual table, **`documents_fts`**, with one row per document. Content is built from:
+
+| Logical content        | Source tables/columns                          |
+|------------------------|-------------------------------------------------|
+| Document title         | `documents.title`                              |
+| Processed page text    | Concatenation of `pages.text` for the document |
+| Summary text           | `summaries.text` (if present)                   |
+| Keyword values         | `keywords.value` via `document_keywords`       |
+
+These are combined into one or more FTS columns so that a single query can match across title, body, summary, and keywords. Exact column layout (one concatenated column vs separate FTS columns) is defined in the implementation issue; the important point is that all of the above are searchable.
+
+The FTS table will store `document_id` (or equivalent) so that search results can be joined back to `documents` and filtered by place, date, status, etc.
+
+### Synchronization strategy: application-driven
+
+FTS is kept in sync by the **application layer**, not by SQLite triggers. When documents, pages, summaries, or document_keywords change, the application calls into a search/index component to update or rebuild the relevant FTS row(s).
+
+**Trade-offs:**
+
+- **Application-driven (chosen):** Explicit and testable; we can assert on when and how FTS is updated. Easier to reason about in tests and when adding new write paths. Requires that every code path that mutates indexed data calls the update logic.
+- **Trigger-based (alternative):** Automatic sync on every insert/update/delete; no risk of forgetting to update FTS. Harder to debug and to test in isolation; triggers are less visible from application code.
+
+Implementation details (migrations, exact trigger vs repository calls) are left to the follow-up issue that creates the FTS tables and wiring.

--- a/docs/decisions/0011-sqlite-fts5-design.md
+++ b/docs/decisions/0011-sqlite-fts5-design.md
@@ -41,3 +41,13 @@ FTS is kept in sync by the **application layer**, not by SQLite triggers. When d
 - **Trigger-based (alternative):** Automatic sync on every insert/update/delete; no risk of forgetting to update FTS. Harder to debug and to test in isolation; triggers are less visible from application code.
 
 Implementation details (migrations, exact trigger vs repository calls) are left to the follow-up issue that creates the FTS tables and wiring.
+
+## Example queries
+
+The design supports queries that combine FTS matching with filters on the base schema. Examples:
+
+1. **Search documents by full text and filter by place**  
+   Match FTS on a user query, then join to `documents` and filter by `place_id` (or place name via `places`) so results are limited to a chosen location.
+
+2. **Search by text and restrict by date range**  
+   FTS match plus join to `documents` and filter on `created_at` (or another date field) to narrow results to a time window.

--- a/docs/decisions/0011-sqlite-fts5-design.md
+++ b/docs/decisions/0011-sqlite-fts5-design.md
@@ -6,48 +6,12 @@ Status: Accepted
 
 ## Context
 
-The project needs full-text search over documents using SQLite FTS5. We must decide the indexing level (document vs page), which fields to index, and how to keep the FTS table(s) in sync with the base tables. Without a clear design, search features risk inconsistency or inefficiency.
+The project needs full-text search over documents using SQLite FTS5. We had to decide indexing level (document vs page), which fields to index, and how to keep FTS in sync with base tables.
 
 ## Decision
 
-### Indexing level: document-level
+- **Indexing level:** Document-level (one FTS row per document).
+- **Schema:** Single FTS5 table `documents_fts`; indexed content: title, concatenated page text, summary, keywords (see canonical schema in `docs/storage_conventions.md` § Full-Text Search (FTS5)).
+- **Synchronization:** Application-driven (app updates FTS when indexed data changes; no triggers). Chosen for explicitness and testability; trigger-based sync was rejected for Phase 1.
 
-We use **document-level** indexing: one FTS row per document. Page-level indexing (one row per page) is not used in Phase 1.
-
-**Rationale:** Document-level matches the primary use case (“find documents that match this text”) and keeps the schema simple. A single `documents_fts` table is easier to reason about and to sync. Page-level indexing can be added later if we need “jump to page” or per-page search.
-
-### Schema: single FTS table `documents_fts`
-
-One FTS5 virtual table, **`documents_fts`**, with one row per document. Content is built from:
-
-| Logical content        | Source tables/columns                          |
-|------------------------|-------------------------------------------------|
-| Document title         | `documents.title`                              |
-| Processed page text    | Concatenation of `pages.text` for the document |
-| Summary text           | `summaries.text` (if present)                   |
-| Keyword values         | `keywords.value` via `document_keywords`       |
-
-These are combined into one or more FTS columns so that a single query can match across title, body, summary, and keywords. Exact column layout (one concatenated column vs separate FTS columns) is defined in the implementation issue; the important point is that all of the above are searchable.
-
-The FTS table will store `document_id` (or equivalent) so that search results can be joined back to `documents` and filtered by place, date, status, etc.
-
-### Synchronization strategy: application-driven
-
-FTS is kept in sync by the **application layer**, not by SQLite triggers. When documents, pages, summaries, or document_keywords change, the application calls into a search/index component to update or rebuild the relevant FTS row(s).
-
-**Trade-offs:**
-
-- **Application-driven (chosen):** Explicit and testable; we can assert on when and how FTS is updated. Easier to reason about in tests and when adding new write paths. Requires that every code path that mutates indexed data calls the update logic.
-- **Trigger-based (alternative):** Automatic sync on every insert/update/delete; no risk of forgetting to update FTS. Harder to debug and to test in isolation; triggers are less visible from application code.
-
-Implementation details (migrations, exact trigger vs repository calls) are left to the follow-up issue that creates the FTS tables and wiring.
-
-## Example queries
-
-The design supports queries that combine FTS matching with filters on the base schema. Examples:
-
-1. **Search documents by full text and filter by place**  
-   Match FTS on a user query, then join to `documents` and filter by `place_id` (or place name via `places`) so results are limited to a chosen location.
-
-2. **Search by text and restrict by date range**  
-   FTS match plus join to `documents` and filter on `created_at` (or another date field) to narrow results to a time window.
+Full design, field sources, and example queries (e.g. search by text and filter by place or date) are in **`docs/storage_conventions.md` § 7. Full-Text Search (FTS5)**.


### PR DESCRIPTION
## What changed

- Added ADR for SQLite FTS5 design: document-level indexing, single `documents_fts` table, application-driven sync.
- Documented example queries (search by text + filter by place/date) in storage conventions.
- Referenced the FTS5 design in Phase 1 and Milestones so both point at the same source of truth.
- Moved full FTS5 design into `docs/storage_conventions.md` §7 and kept the ADR short (decision only).

## Why

Issue 6: we needed a clear, written FTS5 design before implementing tables/triggers so search stays consistent and testable. Decisions live in the ADR; the canonical schema and behaviour live in storage conventions.

## How to test

- Read `docs/decisions/0011-sqlite-fts5-design.md` — should be short and point to storage conventions.
- Read `docs/storage_conventions.md` §7 — should describe level, schema, sync, and example queries.
- Confirm Phase 1 (§4) and Milestones (v0.1) reference the FTS5 design.

## Checklist

- [x] Documentation updated (ADRs + storage conventions)
- [x] No code changes (design/docs only)