### PR TITLE
Feat/implement initial fts5 tables and synchronization

### DIFF
--- a/assets/sql/migrations/008_add_documents_fts.sql
+++ b/assets/sql/migrations/008_add_documents_fts.sql
@@ -1,0 +1,8 @@
+-- 008_add_documents_fts.sql
+-- Add FTS5 virtual table for full-text search over documents.
+-- One row per document. Sync is application-driven (see docs/storage_conventions.md § 7).
+
+CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
+  document_id UNINDEXED,
+  content
+);

--- a/lib/infrastructure/sqlite/documents_fts_sync.dart
+++ b/lib/infrastructure/sqlite/documents_fts_sync.dart
@@ -1,0 +1,66 @@
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart' show MigrationDb;
+
+/// Application-driven sync of [documents_fts] for a single document.
+///
+/// Reads title, page text, summary, and keywords for [documentId], builds
+/// FTS content, and updates the `documents_fts` table (delete existing row
+/// then insert). Aligns with docs/storage_conventions.md § 7.
+Future<void> syncFtsForDocument(MigrationDb db, String documentId) async {
+  final parts = <String>[];
+
+  final docRows = await db.query(
+    'SELECT title FROM documents WHERE id = ?',
+    [documentId],
+  );
+  if (docRows.isEmpty) return;
+  parts.add((docRows.single['title'] as String?) ?? '');
+
+  final pageRows = await db.query(
+    '''
+    SELECT COALESCE(processed_text, raw_text, '') AS text
+    FROM pages
+    WHERE document_id = ?
+    ORDER BY page_number
+    ''',
+    [documentId],
+  );
+  for (final row in pageRows) {
+    final text = row['text'] as String?;
+    if (text != null && text.isNotEmpty) parts.add(text);
+  }
+
+  final summaryRows = await db.query(
+    'SELECT text FROM summaries WHERE document_id = ?',
+    [documentId],
+  );
+  if (summaryRows.isNotEmpty) {
+    final text = summaryRows.single['text'] as String?;
+    if (text != null && text.isNotEmpty) parts.add(text);
+  }
+
+  final keywordRows = await db.query(
+    '''
+    SELECT k.value
+    FROM document_keywords dk
+    JOIN keywords k ON k.id = dk.keyword_id
+    WHERE dk.document_id = ?
+    ORDER BY k.value
+    ''',
+    [documentId],
+  );
+  for (final row in keywordRows) {
+    final value = row['value'] as String?;
+    if (value != null && value.isNotEmpty) parts.add(value);
+  }
+
+  final content = parts.join(' ');
+
+  await db.execute(
+    'DELETE FROM documents_fts WHERE document_id = ?',
+    [documentId],
+  );
+  await db.execute(
+    'INSERT INTO documents_fts(document_id, content) VALUES (?, ?)',
+    [documentId, content],
+  );
+}

--- a/test/infrastructure/sqlite/migrations/migration_runner_test.dart
+++ b/test/infrastructure/sqlite/migrations/migration_runner_test.dart
@@ -57,6 +57,8 @@ Future<List<Migration>> _loadTestMigrations() async {
       'assets/sql/migrations/006_add_document_keywords.sql');
   final embeddingsSql =
       await rootBundle.loadString('assets/sql/migrations/007_add_embeddings.sql');
+  final documentsFtsSql = await rootBundle.loadString(
+      'assets/sql/migrations/008_add_documents_fts.sql');
 
   return <Migration>[
     Migration(
@@ -86,6 +88,10 @@ Future<List<Migration>> _loadTestMigrations() async {
     Migration(
       name: '007_add_embeddings',
       sql: embeddingsSql,
+    ),
+    Migration(
+      name: '008_add_documents_fts',
+      sql: documentsFtsSql,
     ),
   ];
 }


### PR DESCRIPTION
## What changed

- Added migration `008_add_documents_fts.sql` creating the FTS5 virtual table `documents_fts` (document_id + content).
- Implemented application-level FTS sync in `documents_fts_sync.dart`: `syncFtsForDocument(db, documentId)` builds content from document title, pages, summary, and keywords and upserts one row per document.
- Added integration test that inserts a document with pages, runs the sync, and asserts FTS `MATCH` returns the expected document (and that a non-matching term returns no rows).

## Why

Phase 1 needs a working FTS path so we can search documents by text. Design is in Issue 6 and `docs/storage_conventions.md` § 7 (document-level, app-driven sync, no triggers). This implements the table and sync; wiring into repositories can follow in a later PR.

## How to test

- `flutter test test/infrastructure/sqlite/migrations/migration_runner_test.dart` — all 7 tests should pass, including "FTS sync and MATCH return expected document".

**Checklist:** 
- [x] Tests added 
- [x] No new ADRs (design already in 0011 + storage_conventions) 
- [x] Linter clean 
- [x] No debug/TODOs