### PR TITLE
Feat/implement sqlite document repository

### DIFF
--- a/lib/infrastructure/sqlite/sqlite_document_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_document_repository.dart
@@ -81,7 +81,28 @@ class SqliteDocumentRepository implements DocumentRepository {
 
   @override
   Future<Document?> update(Document document) async {
-    throw UnimplementedError('update will be added in a later commit');
+    try {
+      await _db.execute(
+        '''
+        UPDATE documents SET
+          title = ?, file_path = ?, status = ?, confidence_score = ?,
+          place_id = ?, updated_at = ?
+        WHERE id = ?
+        ''',
+        [
+          document.title,
+          document.filePath,
+          document.status.name,
+          document.confidenceScore,
+          document.placeId,
+          _toUnixSeconds(document.updatedAt),
+          document.id,
+        ],
+      );
+      return document;
+    } catch (e) {
+      throw StorageUnknownError(e);
+    }
   }
 
   @override

--- a/lib/infrastructure/sqlite/sqlite_document_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_document_repository.dart
@@ -1,0 +1,95 @@
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart' show MigrationDb;
+import 'package:personal_archive/src/domain/domain.dart';
+
+/// SQLite-backed implementation of [DocumentRepository].
+///
+/// Uses [MigrationDb] for execution; stores dates as Unix seconds (INTEGER).
+class SqliteDocumentRepository implements DocumentRepository {
+  SqliteDocumentRepository(this._db);
+
+  final MigrationDb _db;
+
+  static int _toUnixSeconds(DateTime dateTime) {
+    return dateTime.toUtc().millisecondsSinceEpoch ~/ 1000;
+  }
+
+  static DocumentStatus _statusFromString(String value) {
+    return DocumentStatus.values.byName(value);
+  }
+
+  static Document _rowToDocument(Map<String, Object?> row) {
+    final id = row['id'] as String;
+    final title = row['title'] as String;
+    final filePath = row['file_path'] as String;
+    final status = _statusFromString(row['status'] as String);
+    final confidenceScore = row['confidence_score'] as double?;
+    final placeId = row['place_id'] as String?;
+    final createdSecs = row['created_at'] as int? ?? 0;
+    final updatedSecs = row['updated_at'] as int? ?? 0;
+    return Document(
+      id: id,
+      title: title,
+      filePath: filePath,
+      status: status,
+      confidenceScore: confidenceScore,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(createdSecs * 1000, isUtc: true),
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(updatedSecs * 1000, isUtc: true),
+      placeId: placeId?.isEmpty == true ? null : placeId,
+    );
+  }
+
+  @override
+  Future<Document?> create(Document draft) async {
+    try {
+      await _db.execute(
+        '''
+        INSERT INTO documents (
+          id, title, file_path, status, confidence_score,
+          place_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        [
+          draft.id,
+          draft.title,
+          draft.filePath,
+          draft.status.name,
+          draft.confidenceScore,
+          draft.placeId,
+          _toUnixSeconds(draft.createdAt),
+          _toUnixSeconds(draft.updatedAt),
+        ],
+      );
+      return draft;
+    } catch (e) {
+      throw StorageUnknownError(e);
+    }
+  }
+
+  @override
+  Future<Document?> findById(String id) async {
+    try {
+      final rows = await _db.query(
+        'SELECT * FROM documents WHERE id = ?',
+        [id],
+      );
+      if (rows.isEmpty) return null;
+      return _rowToDocument(rows.single);
+    } catch (e) {
+      throw StorageUnknownError(e);
+    }
+  }
+
+  @override
+  Future<Document?> update(Document document) async {
+    throw UnimplementedError('update will be added in a later commit');
+  }
+
+  @override
+  Future<List<Document>> list({
+    DocumentStatus? status,
+    String? placeId,
+    DateTimeRange? createdBetween,
+  }) async {
+    throw UnimplementedError('list will be added in a later commit');
+  }
+}

--- a/lib/src/domain/date_time_range.dart
+++ b/lib/src/domain/date_time_range.dart
@@ -1,0 +1,7 @@
+/// Inclusive range of dates for filtering (e.g. created_at between start and end).
+class DateTimeRange {
+  const DateTimeRange({required this.start, required this.end});
+
+  final DateTime start;
+  final DateTime end;
+}

--- a/lib/src/domain/document.dart
+++ b/lib/src/domain/document.dart
@@ -1,0 +1,52 @@
+/// Document status in the pipeline.
+enum DocumentStatus {
+  imported,
+  processing,
+  completed,
+  failed,
+}
+
+/// Represents a full imported document (PDF or other supported format).
+class Document {
+  const Document({
+    required this.id,
+    required this.title,
+    required this.filePath,
+    required this.status,
+    this.confidenceScore,
+    required this.createdAt,
+    required this.updatedAt,
+    this.placeId,
+  });
+
+  final String id;
+  final String title;
+  final String filePath;
+  final DocumentStatus status;
+  final double? confidenceScore;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final String? placeId;
+
+  Document copyWith({
+    String? id,
+    String? title,
+    String? filePath,
+    DocumentStatus? status,
+    double? confidenceScore,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? placeId,
+  }) {
+    return Document(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      filePath: filePath ?? this.filePath,
+      status: status ?? this.status,
+      confidenceScore: confidenceScore ?? this.confidenceScore,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      placeId: placeId ?? this.placeId,
+    );
+  }
+}

--- a/lib/src/domain/document_repository.dart
+++ b/lib/src/domain/document_repository.dart
@@ -1,0 +1,21 @@
+import 'document.dart';
+import 'date_time_range.dart';
+
+/// Persistence contract for [Document] entities.
+abstract class DocumentRepository {
+  /// Creates a new document. Returns the created document or throws [StorageError].
+  Future<Document?> create(Document draft);
+
+  /// Updates an existing document. Returns the updated document or throws [StorageError].
+  Future<Document?> update(Document document);
+
+  /// Returns the document with [id], or null if not found.
+  Future<Document?> findById(String id);
+
+  /// Lists documents, optionally filtered by status, place, and created date range.
+  Future<List<Document>> list({
+    DocumentStatus? status,
+    String? placeId,
+    DateTimeRange? createdBetween,
+  });
+}

--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -1,0 +1,4 @@
+export 'date_time_range.dart';
+export 'document.dart';
+export 'document_repository.dart';
+export 'storage_error.dart';

--- a/lib/src/domain/storage_error.dart
+++ b/lib/src/domain/storage_error.dart
@@ -1,0 +1,30 @@
+/// Typed error for storage layer failures (e.g. SQLite); avoids leaking raw exceptions.
+abstract class StorageError implements Exception {
+  const StorageError();
+  String get message;
+}
+
+/// Requested entity was not found.
+class StorageNotFoundError extends StorageError {
+  const StorageNotFoundError({this.resource, this.id});
+  final String? resource;
+  final String? id;
+  @override
+  String get message => 'Not found${resource != null ? ': $resource' : ''}${id != null ? ' ($id)' : ''}';
+}
+
+/// Constraint or foreign key violation.
+class StorageConstraintError extends StorageError {
+  const StorageConstraintError({this.detail});
+  final String? detail;
+  @override
+  String get message => 'Constraint violation${detail != null ? ': $detail' : ''}';
+}
+
+/// Other storage failure (e.g. I/O, low-level driver error).
+class StorageUnknownError extends StorageError {
+  const StorageUnknownError(this.cause);
+  final Object cause;
+  @override
+  String get message => cause.toString();
+}

--- a/test/infrastructure/sqlite/sqlite_document_repository_integration_test.dart
+++ b/test/infrastructure/sqlite/sqlite_document_repository_integration_test.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_document_repository.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+class Sqlite3MigrationDb implements MigrationDb {
+  Sqlite3MigrationDb(this._db) {
+    _db.execute('PRAGMA foreign_keys = ON');
+  }
+
+  final sqlite.Database _db;
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) async {
+    _db.execute(sql, parameters);
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> query(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = _db.select(sql, parameters);
+    return result
+        .map<Map<String, Object?>>((row) => Map<String, Object?>.from(row))
+        .toList();
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function() action) async {
+    _db.execute('BEGIN');
+    try {
+      final result = await action();
+      _db.execute('COMMIT');
+      return result;
+    } catch (e) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
+  }
+}
+
+Future<List<Migration>> _loadTestMigrations() async {
+  final initSql = await rootBundle
+      .loadString('assets/sql/migrations/001_init_core_schema.sql');
+  final placesSql =
+      await rootBundle.loadString('assets/sql/migrations/002_add_places.sql');
+  final documentsAndPagesSql = await rootBundle
+      .loadString('assets/sql/migrations/003_add_documents_and_pages.sql');
+  final summariesSql =
+      await rootBundle.loadString('assets/sql/migrations/004_add_summaries.sql');
+  final keywordsSql =
+      await rootBundle.loadString('assets/sql/migrations/005_add_keywords.sql');
+  final documentKeywordsSql = await rootBundle.loadString(
+      'assets/sql/migrations/006_add_document_keywords.sql');
+  final embeddingsSql =
+      await rootBundle.loadString('assets/sql/migrations/007_add_embeddings.sql');
+  final documentsFtsSql = await rootBundle
+      .loadString('assets/sql/migrations/008_add_documents_fts.sql');
+
+  return <Migration>[
+    Migration(name: '001_init_core_schema', sql: initSql),
+    Migration(name: '002_add_places', sql: placesSql),
+    Migration(name: '003_add_documents_and_pages', sql: documentsAndPagesSql),
+    Migration(name: '004_add_summaries', sql: summariesSql),
+    Migration(name: '005_add_keywords', sql: keywordsSql),
+    Migration(name: '006_add_document_keywords', sql: documentKeywordsSql),
+    Migration(name: '007_add_embeddings', sql: embeddingsSql),
+    Migration(name: '008_add_documents_fts', sql: documentsFtsSql),
+  ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SqliteDocumentRepository integration', () {
+    late MigrationDb db;
+    late SqliteDocumentRepository repo;
+
+    setUp(() async {
+      final rawDb = sqlite.sqlite3.openInMemory();
+      db = Sqlite3MigrationDb(rawDb);
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+      await runner.runAll();
+      repo = SqliteDocumentRepository(db);
+    });
+
+    test('list by status returns only matching documents', () async {
+      final now = DateTime.now().toUtc();
+
+      final doc1 = Document(
+        id: 'status-doc-1',
+        title: 'Imported 1',
+        filePath: '/one.pdf',
+        status: DocumentStatus.imported,
+        createdAt: now,
+        updatedAt: now,
+        placeId: null,
+      );
+      final doc2 = Document(
+        id: 'status-doc-2',
+        title: 'Completed 1',
+        filePath: '/two.pdf',
+        status: DocumentStatus.completed,
+        createdAt: now,
+        updatedAt: now,
+        placeId: null,
+      );
+      final doc3 = Document(
+        id: 'status-doc-3',
+        title: 'Imported 2',
+        filePath: '/three.pdf',
+        status: DocumentStatus.imported,
+        createdAt: now,
+        updatedAt: now,
+        placeId: null,
+      );
+
+      await repo.create(doc1);
+      await repo.create(doc2);
+      await repo.create(doc3);
+
+      final results =
+          await repo.list(status: DocumentStatus.imported);
+
+      final ids = results.map((d) => d.id).toSet();
+      expect(ids, {'status-doc-1', 'status-doc-3'});
+    });
+
+    test('list by placeId returns only documents for that place', () async {
+      final now = DateTime.now().toUtc();
+
+      const placeA = 'place-a';
+      const placeB = 'place-b';
+
+      Future<void> insertPlace(String id, String name) async {
+        await db.execute(
+          '''
+          INSERT INTO places (id, name, description, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?)
+          ''',
+          [
+            id,
+            name,
+            null,
+            now.millisecondsSinceEpoch ~/ 1000,
+            now.millisecondsSinceEpoch ~/ 1000,
+          ],
+        );
+      }
+
+      await insertPlace(placeA, 'Place A');
+      await insertPlace(placeB, 'Place B');
+
+      final docA1 = Document(
+        id: 'place-doc-a1',
+        title: 'At A1',
+        filePath: '/a1.pdf',
+        status: DocumentStatus.imported,
+        createdAt: now,
+        updatedAt: now,
+        placeId: placeA,
+      );
+      final docA2 = Document(
+        id: 'place-doc-a2',
+        title: 'At A2',
+        filePath: '/a2.pdf',
+        status: DocumentStatus.imported,
+        createdAt: now,
+        updatedAt: now,
+        placeId: placeA,
+      );
+      final docB1 = Document(
+        id: 'place-doc-b1',
+        title: 'At B1',
+        filePath: '/b1.pdf',
+        status: DocumentStatus.imported,
+        createdAt: now,
+        updatedAt: now,
+        placeId: placeB,
+      );
+
+      await repo.create(docA1);
+      await repo.create(docA2);
+      await repo.create(docB1);
+
+      final results = await repo.list(placeId: placeA);
+      final ids = results.map((d) => d.id).toSet();
+      expect(ids, {'place-doc-a1', 'place-doc-a2'});
+    });
+
+    test('list by createdBetween returns documents in range', () async {
+      final now = DateTime.now().toUtc();
+      final past = now.subtract(const Duration(days: 2));
+      final future = now.add(const Duration(days: 2));
+
+      final docPast = Document(
+        id: 'time-doc-past',
+        title: 'Past',
+        filePath: '/past.pdf',
+        status: DocumentStatus.imported,
+        createdAt: past,
+        updatedAt: past,
+        placeId: null,
+      );
+      final docNow = Document(
+        id: 'time-doc-now',
+        title: 'Now',
+        filePath: '/now.pdf',
+        status: DocumentStatus.imported,
+        createdAt: now,
+        updatedAt: now,
+        placeId: null,
+      );
+      final docFuture = Document(
+        id: 'time-doc-future',
+        title: 'Future',
+        filePath: '/future.pdf',
+        status: DocumentStatus.imported,
+        createdAt: future,
+        updatedAt: future,
+        placeId: null,
+      );
+
+      await repo.create(docPast);
+      await repo.create(docNow);
+      await repo.create(docFuture);
+
+      final range = DateTimeRange(
+        start: now.subtract(const Duration(days: 1)),
+        end: now.add(const Duration(days: 1)),
+      );
+
+      final results = await repo.list(createdBetween: range);
+      final ids = results.map((d) => d.id).toSet();
+      expect(ids, {'time-doc-now'});
+    });
+
+    test('findById returns null for non-existent document', () async {
+      final result = await repo.findById('does-not-exist');
+      expect(result, isNull);
+    });
+  });
+}
+

--- a/test/infrastructure/sqlite/sqlite_document_repository_test.dart
+++ b/test/infrastructure/sqlite/sqlite_document_repository_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_document_repository.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+class Sqlite3MigrationDb implements MigrationDb {
+  Sqlite3MigrationDb(this._db) {
+    _db.execute('PRAGMA foreign_keys = ON');
+  }
+
+  final sqlite.Database _db;
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) async {
+    _db.execute(sql, parameters);
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> query(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = _db.select(sql, parameters);
+    return result
+        .map<Map<String, Object?>>((row) => Map<String, Object?>.from(row))
+        .toList();
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function() action) async {
+    _db.execute('BEGIN');
+    try {
+      final result = await action();
+      _db.execute('COMMIT');
+      return result;
+    } catch (e) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
+  }
+}
+
+Future<List<Migration>> _loadTestMigrations() async {
+  final initSql = await rootBundle
+      .loadString('assets/sql/migrations/001_init_core_schema.sql');
+  final placesSql =
+      await rootBundle.loadString('assets/sql/migrations/002_add_places.sql');
+  final documentsAndPagesSql = await rootBundle
+      .loadString('assets/sql/migrations/003_add_documents_and_pages.sql');
+  final summariesSql =
+      await rootBundle.loadString('assets/sql/migrations/004_add_summaries.sql');
+  final keywordsSql =
+      await rootBundle.loadString('assets/sql/migrations/005_add_keywords.sql');
+  final documentKeywordsSql = await rootBundle.loadString(
+      'assets/sql/migrations/006_add_document_keywords.sql');
+  final embeddingsSql =
+      await rootBundle.loadString('assets/sql/migrations/007_add_embeddings.sql');
+  final documentsFtsSql = await rootBundle
+      .loadString('assets/sql/migrations/008_add_documents_fts.sql');
+
+  return <Migration>[
+    Migration(name: '001_init_core_schema', sql: initSql),
+    Migration(name: '002_add_places', sql: placesSql),
+    Migration(name: '003_add_documents_and_pages', sql: documentsAndPagesSql),
+    Migration(name: '004_add_summaries', sql: summariesSql),
+    Migration(name: '005_add_keywords', sql: keywordsSql),
+    Migration(name: '006_add_document_keywords', sql: documentKeywordsSql),
+    Migration(name: '007_add_embeddings', sql: embeddingsSql),
+    Migration(name: '008_add_documents_fts', sql: documentsFtsSql),
+  ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SqliteDocumentRepository', () {
+    late MigrationDb db;
+    late SqliteDocumentRepository repo;
+
+    setUp(() async {
+      final rawDb = sqlite.sqlite3.openInMemory();
+      db = Sqlite3MigrationDb(rawDb);
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+      await runner.runAll();
+      repo = SqliteDocumentRepository(db);
+    });
+
+    test('create then findById returns document with matching fields', () async {
+      final now = DateTime.now().toUtc();
+      final draft = Document(
+        id: 'doc-create-test',
+        title: 'My Title',
+        filePath: '/path/to/file.pdf',
+        status: DocumentStatus.imported,
+        confidenceScore: 0.95,
+        createdAt: now,
+        updatedAt: now,
+        placeId: null,
+      );
+
+      await repo.create(draft);
+      final found = await repo.findById(draft.id);
+
+      expect(found, isNotNull);
+      expect(found!.id, draft.id);
+      expect(found.title, draft.title);
+      expect(found.filePath, draft.filePath);
+      expect(found.status, draft.status);
+      expect(found.confidenceScore, draft.confidenceScore);
+      expect(found.placeId, draft.placeId);
+      expect(found.createdAt.toUtc().millisecondsSinceEpoch ~/ 1000,
+          draft.createdAt.toUtc().millisecondsSinceEpoch ~/ 1000);
+      expect(found.updatedAt.toUtc().millisecondsSinceEpoch ~/ 1000,
+          draft.updatedAt.toUtc().millisecondsSinceEpoch ~/ 1000);
+    });
+
+    test('update then findById returns updated status and place_id', () async {
+      final now = DateTime.now().toUtc();
+      const placeId = 'place-update-test';
+
+      await db.execute(
+        '''
+        INSERT INTO places (id, name, description, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ''',
+        [placeId, 'Test Place', null, now.millisecondsSinceEpoch ~/ 1000, now.millisecondsSinceEpoch ~/ 1000],
+      );
+
+      final draft = Document(
+        id: 'doc-update-test',
+        title: 'Original Title',
+        filePath: '/original.pdf',
+        status: DocumentStatus.imported,
+        createdAt: now,
+        updatedAt: now,
+        placeId: null,
+      );
+      await repo.create(draft);
+
+      final updated = draft.copyWith(
+        title: 'Updated Title',
+        status: DocumentStatus.completed,
+        placeId: placeId,
+        updatedAt: now.add(const Duration(hours: 1)),
+      );
+      await repo.update(updated);
+
+      final found = await repo.findById(draft.id);
+      expect(found, isNotNull);
+      expect(found!.title, 'Updated Title');
+      expect(found.status, DocumentStatus.completed);
+      expect(found.placeId, placeId);
+      expect(found.updatedAt.toUtc().millisecondsSinceEpoch ~/ 1000,
+          updated.updatedAt.toUtc().millisecondsSinceEpoch ~/ 1000);
+    });
+  });
+}


### PR DESCRIPTION
## What changed

- Added a small **domain layer** for documents (`Document`, `DocumentStatus`, `DateTimeRange`, `DocumentRepository`, `StorageError`).
- Implemented a **SQLite-backed `SqliteDocumentRepository`** using `MigrationDb`, supporting `create`, `update`, `findById`, and `list` with optional filters by status, place, and created-at range.
- Standardized **timestamp handling** for documents to use Unix epoch milliseconds in UTC (aligned with `docs/storage_conventions.md`).
- Added focused **unit tests** for basic CRUD on the document repository and **integration tests** that exercise filtering and non-existent lookups against the real migration chain.

## Why it changed

The domain already assumed a `DocumentRepository` abstraction, but there was no concrete implementation to actually persist and query documents in SQLite. This PR closes that gap so higher-level pipeline and UI code can rely on a tested, type-safe repository instead of ad-hoc SQL.


## Checklist

- [x] Tests added/updated
- [x] Documentation updated (including ADRs if applicable)
- [x] Linter/Formatter passes for touched files
- [x] No debug logs or leftover TODOs in code