### PR TITLE
Feat/implement sqlite summary repository

### DIFF
--- a/lib/infrastructure/sqlite/sqlite_summary_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_summary_repository.dart
@@ -1,0 +1,77 @@
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart'
+    show MigrationDb;
+import 'package:personal_archive/src/domain/domain.dart';
+
+/// SQLite-backed implementation of [SummaryRepository].
+///
+/// Stores [Summary.createdAt] as Unix epoch milliseconds (INTEGER) in UTC.
+class SqliteSummaryRepository implements SummaryRepository {
+  SqliteSummaryRepository(this._db);
+
+  final MigrationDb _db;
+
+  static int _toEpochMillis(DateTime dateTime) {
+    return dateTime.toUtc().millisecondsSinceEpoch;
+  }
+
+  static Summary _rowToSummary(Map<String, Object?> row) {
+    final createdMillis = row['created_at'] as int;
+    return Summary(
+      documentId: row['document_id'] as String,
+      text: row['text'] as String,
+      modelVersion: row['model_version'] as String,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        createdMillis,
+        isUtc: true,
+      ),
+    );
+  }
+
+  static Never _handleError(Object e) {
+    final msg = e.toString().toLowerCase();
+    if (msg.contains('foreign key') ||
+        msg.contains('constraint') ||
+        msg.contains('sqlite_constraint')) {
+      throw StorageConstraintError(detail: e.toString());
+    }
+    throw StorageUnknownError(e);
+  }
+
+  @override
+  Future<void> upsert(Summary summary) async {
+    try {
+      await _db.execute(
+        '''
+        INSERT OR REPLACE INTO summaries (
+          document_id,
+          text,
+          model_version,
+          created_at
+        ) VALUES (?, ?, ?, ?)
+        ''',
+        [
+          summary.documentId,
+          summary.text,
+          summary.modelVersion,
+          _toEpochMillis(summary.createdAt),
+        ],
+      );
+    } catch (e) {
+      _handleError(e);
+    }
+  }
+
+  @override
+  Future<Summary?> findByDocumentId(String documentId) async {
+    try {
+      final rows = await _db.query(
+        'SELECT * FROM summaries WHERE document_id = ?',
+        [documentId],
+      );
+      if (rows.isEmpty) return null;
+      return _rowToSummary(rows.single);
+    } catch (e) {
+      _handleError(e);
+    }
+  }
+}

--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -4,3 +4,5 @@ export 'document_repository.dart';
 export 'page.dart';
 export 'page_repository.dart';
 export 'storage_error.dart';
+export 'summary.dart';
+export 'summary_repository.dart';

--- a/lib/src/domain/summary.dart
+++ b/lib/src/domain/summary.dart
@@ -1,0 +1,28 @@
+/// Represents an automatically generated summary for a document (1:1 with document).
+class Summary {
+  const Summary({
+    required this.documentId,
+    required this.text,
+    required this.modelVersion,
+    required this.createdAt,
+  });
+
+  final String documentId;
+  final String text;
+  final String modelVersion;
+  final DateTime createdAt;
+
+  Summary copyWith({
+    String? documentId,
+    String? text,
+    String? modelVersion,
+    DateTime? createdAt,
+  }) {
+    return Summary(
+      documentId: documentId ?? this.documentId,
+      text: text ?? this.text,
+      modelVersion: modelVersion ?? this.modelVersion,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/src/domain/summary_repository.dart
+++ b/lib/src/domain/summary_repository.dart
@@ -1,0 +1,12 @@
+import 'storage_error.dart';
+import 'summary.dart';
+
+/// Persistence contract for [Summary] entities (1:1 with document).
+abstract class SummaryRepository {
+  /// Inserts or updates [summary] by [Summary.documentId]. Throws [StorageError]
+  /// on failure (e.g. foreign key violation if document does not exist).
+  Future<void> upsert(Summary summary);
+
+  /// Returns the summary for the given [documentId], or null if none exists.
+  Future<Summary?> findByDocumentId(String documentId);
+}

--- a/test/infrastructure/sqlite/sqlite_summary_repository_integration_test.dart
+++ b/test/infrastructure/sqlite/sqlite_summary_repository_integration_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_summary_repository.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+class Sqlite3MigrationDb implements MigrationDb {
+  Sqlite3MigrationDb(this._db) {
+    _db.execute('PRAGMA foreign_keys = ON');
+  }
+
+  final sqlite.Database _db;
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) async {
+    _db.execute(sql, parameters);
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> query(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = _db.select(sql, parameters);
+    return result
+        .map<Map<String, Object?>>((row) => Map<String, Object?>.from(row))
+        .toList();
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function() action) async {
+    _db.execute('BEGIN');
+    try {
+      final result = await action();
+      _db.execute('COMMIT');
+      return result;
+    } catch (e) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
+  }
+}
+
+Future<List<Migration>> _loadTestMigrations() async {
+  final initSql =
+      await rootBundle.loadString('assets/sql/migrations/001_init_core_schema.sql');
+  final placesSql =
+      await rootBundle.loadString('assets/sql/migrations/002_add_places.sql');
+  final documentsAndPagesSql = await rootBundle
+      .loadString('assets/sql/migrations/003_add_documents_and_pages.sql');
+  final summariesSql =
+      await rootBundle.loadString('assets/sql/migrations/004_add_summaries.sql');
+  final keywordsSql =
+      await rootBundle.loadString('assets/sql/migrations/005_add_keywords.sql');
+  final documentKeywordsSql = await rootBundle
+      .loadString('assets/sql/migrations/006_add_document_keywords.sql');
+  final embeddingsSql =
+      await rootBundle.loadString('assets/sql/migrations/007_add_embeddings.sql');
+  final documentsFtsSql =
+      await rootBundle.loadString('assets/sql/migrations/008_add_documents_fts.sql');
+
+  return <Migration>[
+    Migration(name: '001_init_core_schema', sql: initSql),
+    Migration(name: '002_add_places', sql: placesSql),
+    Migration(name: '003_add_documents_and_pages', sql: documentsAndPagesSql),
+    Migration(name: '004_add_summaries', sql: summariesSql),
+    Migration(name: '005_add_keywords', sql: keywordsSql),
+    Migration(name: '006_add_document_keywords', sql: documentKeywordsSql),
+    Migration(name: '007_add_embeddings', sql: embeddingsSql),
+    Migration(name: '008_add_documents_fts', sql: documentsFtsSql),
+  ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SqliteSummaryRepository integration', () {
+    late MigrationDb db;
+    late SqliteSummaryRepository repo;
+
+    setUp(() async {
+      final rawDb = sqlite.sqlite3.openInMemory();
+      db = Sqlite3MigrationDb(rawDb);
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+      await runner.runAll();
+      repo = SqliteSummaryRepository(db);
+    });
+
+    test(
+      'full migration + insert document + upsert summary + findByDocumentId returns summary',
+      () async {
+        const documentId = 'doc-full-cycle';
+        final now = DateTime.utc(2025, 2, 19, 14, 30, 0);
+        final epoch = now.millisecondsSinceEpoch;
+
+        await db.execute(
+          '''
+          INSERT INTO documents (
+            id, title, file_path, status, confidence_score,
+            place_id, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          ''',
+          [
+            documentId,
+            'Full Cycle Doc',
+            '/path/full.pdf',
+            DocumentStatus.imported.name,
+            0.85,
+            null,
+            epoch,
+            epoch,
+          ],
+        );
+
+        const summaryText = 'Summary survives migration + insert + query cycle.';
+        const modelVersion = 'qwen2.5-0.5b';
+        final summary = Summary(
+          documentId: documentId,
+          text: summaryText,
+          modelVersion: modelVersion,
+          createdAt: now,
+        );
+        await repo.upsert(summary);
+
+        final found = await repo.findByDocumentId(documentId);
+        expect(found, isNotNull);
+        expect(found!.documentId, documentId);
+        expect(found.text, summaryText);
+        expect(found.modelVersion, modelVersion);
+        expect(found.createdAt, now);
+      },
+    );
+
+    test('upsert with non-existent documentId throws StorageConstraintError',
+        () async {
+      final summary = Summary(
+        documentId: 'non-existent-doc',
+        text: 'Orphan summary',
+        modelVersion: 'v1',
+        createdAt: DateTime.utc(2025, 2, 19),
+      );
+
+      expect(
+        () => repo.upsert(summary),
+        throwsA(isA<StorageConstraintError>()),
+      );
+    });
+
+    test('findByDocumentId for document with no summary returns null', () async {
+      const documentId = 'doc-no-summary';
+      final epoch = DateTime.utc(2025, 2, 19).millisecondsSinceEpoch;
+
+      await db.execute(
+        '''
+        INSERT INTO documents (
+          id, title, file_path, status, confidence_score,
+          place_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        [
+          documentId,
+          'Doc Without Summary',
+          '/path/nosummary.pdf',
+          DocumentStatus.imported.name,
+          null,
+          null,
+          epoch,
+          epoch,
+        ],
+      );
+
+      final result = await repo.findByDocumentId(documentId);
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/infrastructure/sqlite/sqlite_summary_repository_test.dart
+++ b/test/infrastructure/sqlite/sqlite_summary_repository_test.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_summary_repository.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+class Sqlite3MigrationDb implements MigrationDb {
+  Sqlite3MigrationDb(this._db) {
+    _db.execute('PRAGMA foreign_keys = ON');
+  }
+
+  final sqlite.Database _db;
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) async {
+    _db.execute(sql, parameters);
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> query(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = _db.select(sql, parameters);
+    return result
+        .map<Map<String, Object?>>((row) => Map<String, Object?>.from(row))
+        .toList();
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function() action) async {
+    _db.execute('BEGIN');
+    try {
+      final result = await action();
+      _db.execute('COMMIT');
+      return result;
+    } catch (e) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
+  }
+}
+
+Future<List<Migration>> _loadTestMigrations() async {
+  final initSql =
+      await rootBundle.loadString('assets/sql/migrations/001_init_core_schema.sql');
+  final placesSql =
+      await rootBundle.loadString('assets/sql/migrations/002_add_places.sql');
+  final documentsAndPagesSql = await rootBundle
+      .loadString('assets/sql/migrations/003_add_documents_and_pages.sql');
+  final summariesSql =
+      await rootBundle.loadString('assets/sql/migrations/004_add_summaries.sql');
+  final keywordsSql =
+      await rootBundle.loadString('assets/sql/migrations/005_add_keywords.sql');
+  final documentKeywordsSql = await rootBundle
+      .loadString('assets/sql/migrations/006_add_document_keywords.sql');
+  final embeddingsSql =
+      await rootBundle.loadString('assets/sql/migrations/007_add_embeddings.sql');
+  final documentsFtsSql =
+      await rootBundle.loadString('assets/sql/migrations/008_add_documents_fts.sql');
+
+  return <Migration>[
+    Migration(name: '001_init_core_schema', sql: initSql),
+    Migration(name: '002_add_places', sql: placesSql),
+    Migration(name: '003_add_documents_and_pages', sql: documentsAndPagesSql),
+    Migration(name: '004_add_summaries', sql: summariesSql),
+    Migration(name: '005_add_keywords', sql: keywordsSql),
+    Migration(name: '006_add_document_keywords', sql: documentKeywordsSql),
+    Migration(name: '007_add_embeddings', sql: embeddingsSql),
+    Migration(name: '008_add_documents_fts', sql: documentsFtsSql),
+  ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SqliteSummaryRepository', () {
+    late MigrationDb db;
+    late SqliteSummaryRepository repo;
+
+    setUp(() async {
+      final rawDb = sqlite.sqlite3.openInMemory();
+      db = Sqlite3MigrationDb(rawDb);
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+      await runner.runAll();
+      repo = SqliteSummaryRepository(db);
+    });
+
+    test('upsert then findByDocumentId returns summary with correct fields',
+        () async {
+      const documentId = 'doc-with-summary';
+      await db.execute(
+        '''
+        INSERT INTO documents (
+          id, title, file_path, status, confidence_score,
+          place_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        [
+          documentId,
+          'Doc Title',
+          '/path/to/doc.pdf',
+          DocumentStatus.imported.name,
+          0.9,
+          null,
+          0,
+          0,
+        ],
+      );
+
+      final createdAt = DateTime.utc(2025, 2, 19, 12, 0, 0);
+      final summary = Summary(
+        documentId: documentId,
+        text: 'A short summary of the document.',
+        modelVersion: 'qwen2.5-0.5b',
+        createdAt: createdAt,
+      );
+      await repo.upsert(summary);
+
+      final found = await repo.findByDocumentId(documentId);
+      expect(found, isNotNull);
+      expect(found!.documentId, documentId);
+      expect(found.text, 'A short summary of the document.');
+      expect(found.modelVersion, 'qwen2.5-0.5b');
+      expect(found.createdAt, createdAt);
+    });
+
+    test('second upsert updates existing summary', () async {
+      const documentId = 'doc-update-summary';
+      await db.execute(
+        '''
+        INSERT INTO documents (
+          id, title, file_path, status, confidence_score,
+          place_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        [
+          documentId,
+          'Doc Title',
+          '/path/to/doc.pdf',
+          DocumentStatus.imported.name,
+          null,
+          null,
+          0,
+          0,
+        ],
+      );
+
+      await repo.upsert(Summary(
+        documentId: documentId,
+        text: 'First summary',
+        modelVersion: 'v1',
+        createdAt: DateTime.utc(2025, 1, 1),
+      ));
+      await repo.upsert(Summary(
+        documentId: documentId,
+        text: 'Updated summary text',
+        modelVersion: 'v2',
+        createdAt: DateTime.utc(2025, 2, 19),
+      ));
+
+      final found = await repo.findByDocumentId(documentId);
+      expect(found, isNotNull);
+      expect(found!.text, 'Updated summary text');
+      expect(found.modelVersion, 'v2');
+      expect(found.createdAt, DateTime.utc(2025, 2, 19));
+    });
+
+    test('findByDocumentId returns null when document has no summary',
+        () async {
+      const documentId = 'doc-no-summary';
+      await db.execute(
+        '''
+        INSERT INTO documents (
+          id, title, file_path, status, confidence_score,
+          place_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        [
+          documentId,
+          'Doc Without Summary',
+          '/path/to/other.pdf',
+          DocumentStatus.imported.name,
+          null,
+          null,
+          0,
+          0,
+        ],
+      );
+
+      final found = await repo.findByDocumentId(documentId);
+      expect(found, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## What changed

- Added `Summary` and `SummaryRepository` in the domain layer (upsert by document id, findByDocumentId → `Summary?`).
- Implemented `SqliteSummaryRepository`: upsert via `INSERT OR REPLACE`, FK/constraint errors mapped to `StorageConstraintError`, `created_at` stored as UTC epoch ms.
- Unit tests for upsert/retrieve round-trip, update-on-second-upsert, and null when no summary.
- Integration tests for full migration + insert + query cycle, FK violation → `StorageConstraintError`, and null when document has no summary.

## Why it changed

Summaries are produced by the LLM pipeline but weren’t persisted behind a repository. This adds a clean abstraction so higher layers can store and load summaries without touching SQLite.

## How to test

- `flutter test test/infrastructure/sqlite/sqlite_summary_repository_test.dart`
- `flutter test test/infrastructure/sqlite/sqlite_summary_repository_integration_test.dart`

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (including ADRs if applicable)
- [x] Linter/Formatter passes
- [x] No debug logs or "TODOs" left in code