### PR TITLE
Feat/implement sqlite keyword and documentkeyword repositories

### DIFF
--- a/lib/infrastructure/sqlite/sqlite_document_keyword_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_document_keyword_repository.dart
@@ -1,0 +1,93 @@
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart'
+    show MigrationDb;
+import 'package:personal_archive/src/domain/domain.dart';
+
+/// SQLite-backed implementation of [DocumentKeywordRepository].
+///
+/// [upsertForDocument] replaces all relations for a document (delete then insert).
+class SqliteDocumentKeywordRepository implements DocumentKeywordRepository {
+  SqliteDocumentKeywordRepository(this._db);
+
+  final MigrationDb _db;
+
+  static Keyword _rowToKeyword(Map<String, Object?> row) {
+    final createdMillis = row['created_at'] as int;
+    return Keyword(
+      id: row['id'] as String,
+      value: row['value'] as String,
+      type: row['type'] as String,
+      globalFrequency: row['global_frequency'] as int,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        createdMillis,
+        isUtc: true,
+      ),
+    );
+  }
+
+  static Never _handleError(Object e) {
+    final msg = e.toString().toLowerCase();
+    if (msg.contains('foreign key') ||
+        msg.contains('constraint') ||
+        msg.contains('sqlite_constraint')) {
+      throw StorageConstraintError(detail: e.toString());
+    }
+    throw StorageUnknownError(e);
+  }
+
+  @override
+  Future<void> upsertForDocument(
+    String documentId,
+    List<DocumentKeywordRelation> relations,
+  ) async {
+    try {
+      await _db.transaction(() async {
+        await _db.execute(
+          'DELETE FROM document_keywords WHERE document_id = ?',
+          [documentId],
+        );
+        for (final r in relations) {
+          await _db.execute(
+            '''
+            INSERT INTO document_keywords (
+              id, document_id, keyword_id, weight, confidence, source
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ''',
+            [
+              r.id,
+              r.documentId,
+              r.keywordId,
+              r.weight,
+              r.confidence,
+              r.source,
+            ],
+          );
+        }
+      });
+    } catch (e) {
+      _handleError(e);
+    }
+  }
+
+  @override
+  Future<List<Keyword>> listForDocument(String documentId) async {
+    try {
+      final rows = await _db.query(
+        '''
+        SELECT
+          k.id AS id,
+          k.value AS value,
+          k.type AS type,
+          k.global_frequency AS global_frequency,
+          k.created_at AS created_at
+        FROM document_keywords dk
+        JOIN keywords k ON dk.keyword_id = k.id
+        WHERE dk.document_id = ?
+        ''',
+        [documentId],
+      );
+      return rows.map(_rowToKeyword).toList();
+    } catch (e) {
+      _handleError(e);
+    }
+  }
+}

--- a/lib/infrastructure/sqlite/sqlite_keyword_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_keyword_repository.dart
@@ -1,0 +1,91 @@
+import 'dart:math';
+
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart'
+    show MigrationDb;
+import 'package:personal_archive/src/domain/domain.dart';
+
+/// SQLite-backed implementation of [KeywordRepository].
+///
+/// Stores [Keyword.createdAt] as Unix epoch milliseconds (INTEGER) in UTC.
+class SqliteKeywordRepository implements KeywordRepository {
+  SqliteKeywordRepository(this._db);
+
+  final MigrationDb _db;
+  static final Random _random = Random();
+
+  static int _toEpochMillis(DateTime dateTime) {
+    return dateTime.toUtc().millisecondsSinceEpoch;
+  }
+
+  static Keyword _rowToKeyword(Map<String, Object?> row) {
+    final createdMillis = row['created_at'] as int;
+    return Keyword(
+      id: row['id'] as String,
+      value: row['value'] as String,
+      type: row['type'] as String,
+      globalFrequency: row['global_frequency'] as int,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        createdMillis,
+        isUtc: true,
+      ),
+    );
+  }
+
+  static String _generateId() {
+    final micro = DateTime.now().microsecondsSinceEpoch.toRadixString(36);
+    final r = _random.nextInt(0x7FFFFFFF).toRadixString(36);
+    return '$micro-$r';
+  }
+
+  static Never _handleError(Object e) {
+    final msg = e.toString().toLowerCase();
+    if (msg.contains('foreign key') ||
+        msg.contains('constraint') ||
+        msg.contains('sqlite_constraint')) {
+      throw StorageConstraintError(detail: e.toString());
+    }
+    throw StorageUnknownError(e);
+  }
+
+  @override
+  Future<Keyword> getOrCreate(String value, String type) async {
+    try {
+      final rows = await _db.query(
+        'SELECT * FROM keywords WHERE value = ? AND type = ?',
+        [value, type],
+      );
+      if (rows.isNotEmpty) return _rowToKeyword(rows.single);
+
+      final id = _generateId();
+      final now = DateTime.now().toUtc();
+      await _db.execute(
+        '''
+        INSERT INTO keywords (id, value, type, global_frequency, created_at)
+        VALUES (?, ?, ?, 0, ?)
+        ''',
+        [id, value, type, _toEpochMillis(now)],
+      );
+      return Keyword(
+        id: id,
+        value: value,
+        type: type,
+        globalFrequency: 0,
+        createdAt: now,
+      );
+    } catch (e) {
+      _handleError(e);
+    }
+  }
+
+  @override
+  Future<void> incrementGlobalFrequency(String keywordId) async {
+    try {
+      await _db.execute(
+        'UPDATE keywords SET global_frequency = global_frequency + 1 WHERE id = ?',
+        [keywordId],
+      );
+    } catch (e) {
+      _handleError(e);
+    }
+  }
+}

--- a/lib/src/domain/document_keyword_relation.dart
+++ b/lib/src/domain/document_keyword_relation.dart
@@ -1,0 +1,36 @@
+/// Link between a document and a keyword with weight and confidence for ranking.
+class DocumentKeywordRelation {
+  const DocumentKeywordRelation({
+    required this.id,
+    required this.documentId,
+    required this.keywordId,
+    required this.weight,
+    required this.confidence,
+    this.source,
+  });
+
+  final String id;
+  final String documentId;
+  final String keywordId;
+  final double weight;
+  final double confidence;
+  final String? source;
+
+  DocumentKeywordRelation copyWith({
+    String? id,
+    String? documentId,
+    String? keywordId,
+    double? weight,
+    double? confidence,
+    String? source,
+  }) {
+    return DocumentKeywordRelation(
+      id: id ?? this.id,
+      documentId: documentId ?? this.documentId,
+      keywordId: keywordId ?? this.keywordId,
+      weight: weight ?? this.weight,
+      confidence: confidence ?? this.confidence,
+      source: source ?? this.source,
+    );
+  }
+}

--- a/lib/src/domain/document_keyword_repository.dart
+++ b/lib/src/domain/document_keyword_repository.dart
@@ -1,0 +1,16 @@
+import 'document_keyword_relation.dart';
+import 'keyword.dart';
+import 'storage_error.dart';
+
+/// Persistence contract for document–keyword relations (many-to-many).
+abstract class DocumentKeywordRepository {
+  /// Replaces or updates relations for [documentId] with [relations].
+  /// Throws [StorageError] on failure (e.g. foreign key violation).
+  Future<void> upsertForDocument(
+    String documentId,
+    List<DocumentKeywordRelation> relations,
+  );
+
+  /// Returns the [Keyword] entities linked to the given [documentId].
+  Future<List<Keyword>> listForDocument(String documentId);
+}

--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -1,6 +1,10 @@
 export 'date_time_range.dart';
 export 'document.dart';
+export 'document_keyword_relation.dart';
+export 'document_keyword_repository.dart';
 export 'document_repository.dart';
+export 'keyword.dart';
+export 'keyword_repository.dart';
 export 'page.dart';
 export 'page_repository.dart';
 export 'storage_error.dart';

--- a/lib/src/domain/keyword.dart
+++ b/lib/src/domain/keyword.dart
@@ -1,0 +1,32 @@
+/// Normalized, reusable keyword (e.g. topic, entity) unique by [value] and [type].
+class Keyword {
+  const Keyword({
+    required this.id,
+    required this.value,
+    required this.type,
+    required this.globalFrequency,
+    required this.createdAt,
+  });
+
+  final String id;
+  final String value;
+  final String type;
+  final int globalFrequency;
+  final DateTime createdAt;
+
+  Keyword copyWith({
+    String? id,
+    String? value,
+    String? type,
+    int? globalFrequency,
+    DateTime? createdAt,
+  }) {
+    return Keyword(
+      id: id ?? this.id,
+      value: value ?? this.value,
+      type: type ?? this.type,
+      globalFrequency: globalFrequency ?? this.globalFrequency,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/src/domain/keyword_repository.dart
+++ b/lib/src/domain/keyword_repository.dart
@@ -1,0 +1,13 @@
+import 'keyword.dart';
+import 'storage_error.dart';
+
+/// Persistence contract for [Keyword] entities (unique by value and type).
+abstract class KeywordRepository {
+  /// Returns the keyword for [value] and [type], or creates one if none exists.
+  /// Throws [StorageError] on failure (e.g. unique constraint in a race).
+  Future<Keyword> getOrCreate(String value, String type);
+
+  /// Increments [Keyword.globalFrequency] for the given [keywordId].
+  /// Throws [StorageError] on failure.
+  Future<void> incrementGlobalFrequency(String keywordId);
+}

--- a/test/infrastructure/sqlite/sqlite_keyword_repository_integration_test.dart
+++ b/test/infrastructure/sqlite/sqlite_keyword_repository_integration_test.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_document_keyword_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_keyword_repository.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+class Sqlite3MigrationDb implements MigrationDb {
+  Sqlite3MigrationDb(this._db) {
+    _db.execute('PRAGMA foreign_keys = ON');
+  }
+
+  final sqlite.Database _db;
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) async {
+    _db.execute(sql, parameters);
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> query(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = _db.select(sql, parameters);
+    return result
+        .map<Map<String, Object?>>((row) => Map<String, Object?>.from(row))
+        .toList();
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function() action) async {
+    _db.execute('BEGIN');
+    try {
+      final result = await action();
+      _db.execute('COMMIT');
+      return result;
+    } catch (e) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
+  }
+}
+
+Future<List<Migration>> _loadTestMigrations() async {
+  final initSql =
+      await rootBundle.loadString('assets/sql/migrations/001_init_core_schema.sql');
+  final placesSql =
+      await rootBundle.loadString('assets/sql/migrations/002_add_places.sql');
+  final documentsAndPagesSql = await rootBundle
+      .loadString('assets/sql/migrations/003_add_documents_and_pages.sql');
+  final summariesSql =
+      await rootBundle.loadString('assets/sql/migrations/004_add_summaries.sql');
+  final keywordsSql =
+      await rootBundle.loadString('assets/sql/migrations/005_add_keywords.sql');
+  final documentKeywordsSql = await rootBundle
+      .loadString('assets/sql/migrations/006_add_document_keywords.sql');
+  final embeddingsSql =
+      await rootBundle.loadString('assets/sql/migrations/007_add_embeddings.sql');
+  final documentsFtsSql =
+      await rootBundle.loadString('assets/sql/migrations/008_add_documents_fts.sql');
+
+  return <Migration>[
+    Migration(name: '001_init_core_schema', sql: initSql),
+    Migration(name: '002_add_places', sql: placesSql),
+    Migration(name: '003_add_documents_and_pages', sql: documentsAndPagesSql),
+    Migration(name: '004_add_summaries', sql: summariesSql),
+    Migration(name: '005_add_keywords', sql: keywordsSql),
+    Migration(name: '006_add_document_keywords', sql: documentKeywordsSql),
+    Migration(name: '007_add_embeddings', sql: embeddingsSql),
+    Migration(name: '008_add_documents_fts', sql: documentsFtsSql),
+  ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Keyword and DocumentKeyword integration', () {
+    late MigrationDb db;
+    late SqliteKeywordRepository keywordRepo;
+    late SqliteDocumentKeywordRepository docKeywordRepo;
+
+    setUp(() async {
+      final rawDb = sqlite.sqlite3.openInMemory();
+      db = Sqlite3MigrationDb(rawDb);
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+      await runner.runAll();
+      keywordRepo = SqliteKeywordRepository(db);
+      docKeywordRepo = SqliteDocumentKeywordRepository(db);
+    });
+
+    Future<void> insertDocument(String documentId) async {
+      final epoch = DateTime.utc(2025, 2, 19).millisecondsSinceEpoch;
+      await db.execute(
+        '''
+        INSERT INTO documents (
+          id, title, file_path, status, confidence_score,
+          place_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        [
+          documentId,
+          'Integration Doc',
+          '/path/integration.pdf',
+          DocumentStatus.imported.name,
+          null,
+          null,
+          epoch,
+          epoch,
+        ],
+      );
+    }
+
+    test(
+      'full migration + insert document + upsert relations + listForDocument returns keywords',
+      () async {
+        const documentId = 'doc-integration-cycle';
+        await insertDocument(documentId);
+
+        final k1 = await keywordRepo.getOrCreate('bank', 'topic');
+        final k2 = await keywordRepo.getOrCreate('invoice', 'type');
+
+        await docKeywordRepo.upsertForDocument(
+          documentId,
+          [
+            DocumentKeywordRelation(
+              id: 'rel-int-1',
+              documentId: documentId,
+              keywordId: k1.id,
+              weight: 0.9,
+              confidence: 0.95,
+              source: 'llm',
+            ),
+            DocumentKeywordRelation(
+              id: 'rel-int-2',
+              documentId: documentId,
+              keywordId: k2.id,
+              weight: 0.7,
+              confidence: 0.85,
+            ),
+          ],
+        );
+
+        final keywords = await docKeywordRepo.listForDocument(documentId);
+        expect(keywords.length, 2);
+        final ids = keywords.map((k) => k.id).toSet();
+        expect(ids, containsAll(<String>[k1.id, k2.id]));
+      },
+    );
+
+    test(
+      'repeated getOrCreate and upsertForDocument do not create duplicate rows',
+      () async {
+        const documentId = 'doc-no-duplicates';
+        await insertDocument(documentId);
+
+        final k1 = await keywordRepo.getOrCreate('duplicate', 'topic');
+        final k2 = await keywordRepo.getOrCreate('duplicate', 'topic');
+        expect(k2.id, k1.id);
+
+        final keywordRows = await db.query(
+          '''
+          SELECT COUNT(*) AS count
+          FROM keywords
+          WHERE value = ? AND type = ?
+          ''',
+          ['duplicate', 'topic'],
+        );
+        final keywordCount = keywordRows.single['count'] as int;
+        expect(keywordCount, 1);
+
+        final relations = [
+          DocumentKeywordRelation(
+            id: 'rel-dupe-1',
+            documentId: documentId,
+            keywordId: k1.id,
+            weight: 0.5,
+            confidence: 0.6,
+          ),
+        ];
+
+        await docKeywordRepo.upsertForDocument(documentId, relations);
+        await docKeywordRepo.upsertForDocument(documentId, relations);
+
+        final relationRows = await db.query(
+          '''
+          SELECT COUNT(*) AS count
+          FROM document_keywords
+          WHERE document_id = ?
+          ''',
+          [documentId],
+        );
+        final relationCount = relationRows.single['count'] as int;
+        expect(relationCount, relations.length);
+      },
+    );
+  });
+}
+

--- a/test/infrastructure/sqlite/sqlite_keyword_repository_test.dart
+++ b/test/infrastructure/sqlite/sqlite_keyword_repository_test.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_document_keyword_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_keyword_repository.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+class Sqlite3MigrationDb implements MigrationDb {
+  Sqlite3MigrationDb(this._db) {
+    _db.execute('PRAGMA foreign_keys = ON');
+  }
+
+  final sqlite.Database _db;
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) async {
+    _db.execute(sql, parameters);
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> query(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = _db.select(sql, parameters);
+    return result
+        .map<Map<String, Object?>>((row) => Map<String, Object?>.from(row))
+        .toList();
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function() action) async {
+    _db.execute('BEGIN');
+    try {
+      final result = await action();
+      _db.execute('COMMIT');
+      return result;
+    } catch (e) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
+  }
+}
+
+Future<List<Migration>> _loadTestMigrations() async {
+  final initSql =
+      await rootBundle.loadString('assets/sql/migrations/001_init_core_schema.sql');
+  final placesSql =
+      await rootBundle.loadString('assets/sql/migrations/002_add_places.sql');
+  final documentsAndPagesSql = await rootBundle
+      .loadString('assets/sql/migrations/003_add_documents_and_pages.sql');
+  final summariesSql =
+      await rootBundle.loadString('assets/sql/migrations/004_add_summaries.sql');
+  final keywordsSql =
+      await rootBundle.loadString('assets/sql/migrations/005_add_keywords.sql');
+  final documentKeywordsSql = await rootBundle
+      .loadString('assets/sql/migrations/006_add_document_keywords.sql');
+  final embeddingsSql =
+      await rootBundle.loadString('assets/sql/migrations/007_add_embeddings.sql');
+  final documentsFtsSql =
+      await rootBundle.loadString('assets/sql/migrations/008_add_documents_fts.sql');
+
+  return <Migration>[
+    Migration(name: '001_init_core_schema', sql: initSql),
+    Migration(name: '002_add_places', sql: placesSql),
+    Migration(name: '003_add_documents_and_pages', sql: documentsAndPagesSql),
+    Migration(name: '004_add_summaries', sql: summariesSql),
+    Migration(name: '005_add_keywords', sql: keywordsSql),
+    Migration(name: '006_add_document_keywords', sql: documentKeywordsSql),
+    Migration(name: '007_add_embeddings', sql: embeddingsSql),
+    Migration(name: '008_add_documents_fts', sql: documentsFtsSql),
+  ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SqliteKeywordRepository', () {
+    late MigrationDb db;
+    late SqliteKeywordRepository repo;
+
+    setUp(() async {
+      final rawDb = sqlite.sqlite3.openInMemory();
+      db = Sqlite3MigrationDb(rawDb);
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+      await runner.runAll();
+      repo = SqliteKeywordRepository(db);
+    });
+
+    test('getOrCreate returns new keyword with correct value, type, globalFrequency 0',
+        () async {
+      final keyword = await repo.getOrCreate('bank', 'topic');
+      expect(keyword.value, 'bank');
+      expect(keyword.type, 'topic');
+      expect(keyword.globalFrequency, 0);
+      expect(keyword.id, isNotEmpty);
+      expect(keyword.createdAt, isNotNull);
+    });
+
+    test('getOrCreate with same value and type returns same keyword (reuse)', () async {
+      final k1 = await repo.getOrCreate('invoice', 'type');
+      final k2 = await repo.getOrCreate('invoice', 'type');
+      expect(k2.id, k1.id);
+      expect(k2.value, k1.value);
+      expect(k2.type, k1.type);
+    });
+
+    test('incrementGlobalFrequency increases globalFrequency', () async {
+      final k1 = await repo.getOrCreate('transaction', 'topic');
+      expect(k1.globalFrequency, 0);
+
+      await repo.incrementGlobalFrequency(k1.id);
+
+      final k2 = await repo.getOrCreate('transaction', 'topic');
+      expect(k2.id, k1.id);
+      expect(k2.globalFrequency, 1);
+    });
+  });
+
+  group('SqliteDocumentKeywordRepository', () {
+    late MigrationDb db;
+    late SqliteKeywordRepository keywordRepo;
+    late SqliteDocumentKeywordRepository docKeywordRepo;
+
+    setUp(() async {
+      final rawDb = sqlite.sqlite3.openInMemory();
+      db = Sqlite3MigrationDb(rawDb);
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+      await runner.runAll();
+      keywordRepo = SqliteKeywordRepository(db);
+      docKeywordRepo = SqliteDocumentKeywordRepository(db);
+    });
+
+    Future<void> insertDocument(String documentId) async {
+      await db.execute(
+        '''
+        INSERT INTO documents (
+          id, title, file_path, status, confidence_score,
+          place_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        [
+          documentId,
+          'Test Doc',
+          '/path/to/doc.pdf',
+          DocumentStatus.imported.name,
+          null,
+          null,
+          0,
+          0,
+        ],
+      );
+    }
+
+    test('upsertForDocument then listForDocument returns linked keywords', () async {
+      const documentId = 'doc-with-keywords';
+      await insertDocument(documentId);
+
+      final k1 = await keywordRepo.getOrCreate('bank', 'topic');
+      final k2 = await keywordRepo.getOrCreate('invoice', 'type');
+      final relations = [
+        DocumentKeywordRelation(
+          id: 'rel-1',
+          documentId: documentId,
+          keywordId: k1.id,
+          weight: 0.9,
+          confidence: 0.95,
+          source: 'llm',
+        ),
+        DocumentKeywordRelation(
+          id: 'rel-2',
+          documentId: documentId,
+          keywordId: k2.id,
+          weight: 0.7,
+          confidence: 0.8,
+        ),
+      ];
+      await docKeywordRepo.upsertForDocument(documentId, relations);
+
+      final keywords = await docKeywordRepo.listForDocument(documentId);
+      expect(keywords.length, 2);
+      final ids = keywords.map((k) => k.id).toSet();
+      expect(ids, contains(k1.id));
+      expect(ids, contains(k2.id));
+      final values = keywords.map((k) => k.value).toSet();
+      expect(values, contains('bank'));
+      expect(values, contains('invoice'));
+    });
+
+    test('second upsertForDocument replaces relations (no stale relations)', () async {
+      const documentId = 'doc-replace-keywords';
+      await insertDocument(documentId);
+
+      final k1 = await keywordRepo.getOrCreate('old', 'topic');
+      await docKeywordRepo.upsertForDocument(
+        documentId,
+        [
+          DocumentKeywordRelation(
+            id: 'rel-old',
+            documentId: documentId,
+            keywordId: k1.id,
+            weight: 0.5,
+            confidence: 0.5,
+          ),
+        ],
+      );
+
+      final k2 = await keywordRepo.getOrCreate('new', 'topic');
+      await docKeywordRepo.upsertForDocument(
+        documentId,
+        [
+          DocumentKeywordRelation(
+            id: 'rel-new',
+            documentId: documentId,
+            keywordId: k2.id,
+            weight: 0.8,
+            confidence: 0.9,
+          ),
+        ],
+      );
+
+      final keywords = await docKeywordRepo.listForDocument(documentId);
+      expect(keywords.length, 1);
+      expect(keywords.single.id, k2.id);
+      expect(keywords.single.value, 'new');
+    });
+  });
+}


### PR DESCRIPTION
## What changed

- Added domain entities `Keyword` and `DocumentKeywordRelation` plus interfaces `KeywordRepository` and `DocumentKeywordRepository`.
- Implemented `SqliteKeywordRepository`: `getOrCreate(value, type)` (unique on value+type) and `incrementGlobalFrequency(keywordId)`.
- Implemented `SqliteDocumentKeywordRepository`: `upsertForDocument(documentId, relations)` (delete-then-insert) and `listForDocument(documentId)` returning resolved `Keyword` entities.
- Unit tests for both repos (create/reuse keywords, frequency bump, upsert/list and replace semantics).
- Integration tests: full migration + insert + query cycle, and no duplicate keyword or document_keyword rows.

## Why

The knowledge engine needs normalized keywords and document–keyword links; without a repository layer we’d get duplicates and inconsistent weights. This adds the missing persistence for Phase 1.

## How to test

- `flutter test test/infrastructure/sqlite/sqlite_keyword_repository_test.dart`
- `flutter test test/infrastructure/sqlite/sqlite_keyword_repository_integration_test.dart`
- Or run the full test suite.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (including ADRs if applicable)
- [x] Linter/Formatter passes
- [x] No debug logs or "TODOs" left in code