### PR TITLE
Feat/implement sqlite place repository

### DIFF
--- a/lib/infrastructure/sqlite/sqlite_place_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_place_repository.dart
@@ -1,0 +1,101 @@
+import 'dart:math';
+
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart'
+    show MigrationDb;
+import 'package:personal_archive/src/domain/domain.dart';
+
+/// SQLite-backed implementation of [PlaceRepository].
+///
+/// Name normalization: leading and trailing whitespace is trimmed before lookup
+/// and insert. Names are case-sensitive (no lowercasing), matching SQLite's
+/// default UNIQUE semantics.
+///
+/// Stores [Place.createdAt] and [Place.updatedAt] as Unix epoch milliseconds
+/// (INTEGER) in UTC.
+class SqlitePlaceRepository implements PlaceRepository {
+  SqlitePlaceRepository(this._db);
+
+  final MigrationDb _db;
+  static final Random _random = Random();
+
+  /// Trim leading/trailing whitespace; names remain case-sensitive.
+  static String _normalizeName(String name) => name.trim();
+
+  static int _toEpochMillis(DateTime dateTime) {
+    return dateTime.toUtc().millisecondsSinceEpoch;
+  }
+
+  static Place _rowToPlace(Map<String, Object?> row) {
+    final createdMillis = row['created_at'] as int;
+    final updatedMillis = row['updated_at'] as int;
+    final desc = row['description'];
+    return Place(
+      id: row['id'] as String,
+      name: row['name'] as String,
+      description: desc != null ? desc as String : null,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(createdMillis, isUtc: true),
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(updatedMillis, isUtc: true),
+    );
+  }
+
+  static String _generateId() {
+    final micro = DateTime.now().microsecondsSinceEpoch.toRadixString(36);
+    final r = _random.nextInt(0x7FFFFFFF).toRadixString(36);
+    return '$micro-$r';
+  }
+
+  static Never _handleError(Object e) {
+    final msg = e.toString().toLowerCase();
+    if (msg.contains('foreign key') ||
+        msg.contains('constraint') ||
+        msg.contains('sqlite_constraint')) {
+      throw StorageConstraintError(detail: e.toString());
+    }
+    throw StorageUnknownError(e);
+  }
+
+  @override
+  Future<Place> getOrCreate(String name) async {
+    try {
+      final normalized = _normalizeName(name);
+      final rows = await _db.query(
+        'SELECT * FROM places WHERE name = ?',
+        [normalized],
+      );
+      if (rows.isNotEmpty) return _rowToPlace(rows.single);
+
+      final id = _generateId();
+      final now = DateTime.now().toUtc();
+      final ts = _toEpochMillis(now);
+      await _db.execute(
+        '''
+        INSERT INTO places (id, name, description, created_at, updated_at)
+        VALUES (?, ?, NULL, ?, ?)
+        ''',
+        [id, normalized, ts, ts],
+      );
+      return Place(
+        id: id,
+        name: normalized,
+        description: null,
+        createdAt: now,
+        updatedAt: now,
+      );
+    } catch (e) {
+      _handleError(e);
+    }
+  }
+
+  @override
+  Future<List<Place>> listAll() async {
+    try {
+      final rows = await _db.query(
+        'SELECT * FROM places ORDER BY name',
+        [],
+      );
+      return rows.map(_rowToPlace).toList();
+    } catch (e) {
+      _handleError(e);
+    }
+  }
+}

--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -7,6 +7,8 @@ export 'keyword.dart';
 export 'keyword_repository.dart';
 export 'page.dart';
 export 'page_repository.dart';
+export 'place.dart';
+export 'place_repository.dart';
 export 'storage_error.dart';
 export 'summary.dart';
 export 'summary_repository.dart';

--- a/lib/src/domain/place.dart
+++ b/lib/src/domain/place.dart
@@ -1,0 +1,33 @@
+/// Logical grouping or category (e.g. "Banking", "University") under which documents are organized.
+/// Unique by [name].
+class Place {
+  const Place({
+    required this.id,
+    required this.name,
+    this.description,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String name;
+  final String? description;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  Place copyWith({
+    String? id,
+    String? name,
+    String? description,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return Place(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}

--- a/lib/src/domain/place_repository.dart
+++ b/lib/src/domain/place_repository.dart
@@ -1,0 +1,13 @@
+import 'place.dart';
+import 'storage_error.dart';
+
+/// Persistence contract for [Place] entities (unique by name).
+abstract class PlaceRepository {
+  /// Returns the place for [name], or creates one if none exists.
+  /// Throws [StorageError] on failure (e.g. unique constraint in a race).
+  Future<Place> getOrCreate(String name);
+
+  /// Returns all places in a stable order (e.g. alphabetical by name).
+  /// Throws [StorageError] on failure.
+  Future<List<Place>> listAll();
+}

--- a/test/infrastructure/sqlite/sqlite_place_repository_integration_test.dart
+++ b/test/infrastructure/sqlite/sqlite_place_repository_integration_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_document_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_place_repository.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+class Sqlite3MigrationDb implements MigrationDb {
+  Sqlite3MigrationDb(this._db) {
+    _db.execute('PRAGMA foreign_keys = ON');
+  }
+
+  final sqlite.Database _db;
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) async {
+    _db.execute(sql, parameters);
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> query(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = _db.select(sql, parameters);
+    return result
+        .map<Map<String, Object?>>((row) => Map<String, Object?>.from(row))
+        .toList();
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function() action) async {
+    _db.execute('BEGIN');
+    try {
+      final result = await action();
+      _db.execute('COMMIT');
+      return result;
+    } catch (e) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
+  }
+}
+
+Future<List<Migration>> _loadTestMigrations() async {
+  final initSql = await rootBundle
+      .loadString('assets/sql/migrations/001_init_core_schema.sql');
+  final placesSql =
+      await rootBundle.loadString('assets/sql/migrations/002_add_places.sql');
+  final documentsAndPagesSql = await rootBundle
+      .loadString('assets/sql/migrations/003_add_documents_and_pages.sql');
+  final summariesSql =
+      await rootBundle.loadString('assets/sql/migrations/004_add_summaries.sql');
+  final keywordsSql =
+      await rootBundle.loadString('assets/sql/migrations/005_add_keywords.sql');
+  final documentKeywordsSql = await rootBundle.loadString(
+      'assets/sql/migrations/006_add_document_keywords.sql');
+  final embeddingsSql =
+      await rootBundle.loadString('assets/sql/migrations/007_add_embeddings.sql');
+  final documentsFtsSql = await rootBundle
+      .loadString('assets/sql/migrations/008_add_documents_fts.sql');
+
+  return <Migration>[
+    Migration(name: '001_init_core_schema', sql: initSql),
+    Migration(name: '002_add_places', sql: placesSql),
+    Migration(name: '003_add_documents_and_pages', sql: documentsAndPagesSql),
+    Migration(name: '004_add_summaries', sql: summariesSql),
+    Migration(name: '005_add_keywords', sql: keywordsSql),
+    Migration(name: '006_add_document_keywords', sql: documentKeywordsSql),
+    Migration(name: '007_add_embeddings', sql: embeddingsSql),
+    Migration(name: '008_add_documents_fts', sql: documentsFtsSql),
+  ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SqlitePlaceRepository integration', () {
+    late MigrationDb db;
+    late SqlitePlaceRepository placeRepo;
+    late SqliteDocumentRepository documentRepo;
+
+    setUp(() async {
+      final rawDb = sqlite.sqlite3.openInMemory();
+      db = Sqlite3MigrationDb(rawDb);
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+      await runner.runAll();
+      placeRepo = SqlitePlaceRepository(db);
+      documentRepo = SqliteDocumentRepository(db);
+    });
+
+    test('document can reference place and is stored and retrieved correctly',
+        () async {
+      final place = await placeRepo.getOrCreate('Banking');
+      final now = DateTime.now().toUtc();
+
+      final doc = Document(
+        id: 'doc-with-place',
+        title: 'Bank Doc',
+        filePath: '/bank.pdf',
+        status: DocumentStatus.imported,
+        createdAt: now,
+        updatedAt: now,
+        placeId: place.id,
+      );
+      await documentRepo.create(doc);
+
+      final found = await documentRepo.findById(doc.id);
+      expect(found, isNotNull);
+      expect(found!.placeId, place.id);
+    });
+
+    test('document cannot reference non-existent place (FK constraint)', () async {
+      final now = DateTime.now().toUtc();
+      final doc = Document(
+        id: 'doc-bad-place',
+        title: 'Orphan',
+        filePath: '/orphan.pdf',
+        status: DocumentStatus.imported,
+        createdAt: now,
+        updatedAt: now,
+        placeId: 'non-existent-place-id',
+      );
+
+      await expectLater(
+        documentRepo.create(doc),
+        throwsA(isA<StorageError>()),
+      );
+    });
+
+    test('place referenced by document cannot be deleted (ON DELETE RESTRICT)',
+        () async {
+      final place = await placeRepo.getOrCreate('Projects');
+      final now = DateTime.now().toUtc();
+
+      final doc = Document(
+        id: 'doc-at-place',
+        title: 'Project Doc',
+        filePath: '/project.pdf',
+        status: DocumentStatus.imported,
+        createdAt: now,
+        updatedAt: now,
+        placeId: place.id,
+      );
+      await documentRepo.create(doc);
+
+      await expectLater(
+        db.execute('DELETE FROM places WHERE id = ?', [place.id]),
+        throwsException,
+      );
+    });
+  });
+}

--- a/test/infrastructure/sqlite/sqlite_place_repository_test.dart
+++ b/test/infrastructure/sqlite/sqlite_place_repository_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_place_repository.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+class Sqlite3MigrationDb implements MigrationDb {
+  Sqlite3MigrationDb(this._db) {
+    _db.execute('PRAGMA foreign_keys = ON');
+  }
+
+  final sqlite.Database _db;
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) async {
+    _db.execute(sql, parameters);
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> query(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = _db.select(sql, parameters);
+    return result
+        .map<Map<String, Object?>>((row) => Map<String, Object?>.from(row))
+        .toList();
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function() action) async {
+    _db.execute('BEGIN');
+    try {
+      final result = await action();
+      _db.execute('COMMIT');
+      return result;
+    } catch (e) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
+  }
+}
+
+Future<List<Migration>> _loadTestMigrations() async {
+  final initSql = await rootBundle
+      .loadString('assets/sql/migrations/001_init_core_schema.sql');
+  final placesSql =
+      await rootBundle.loadString('assets/sql/migrations/002_add_places.sql');
+  final documentsAndPagesSql = await rootBundle
+      .loadString('assets/sql/migrations/003_add_documents_and_pages.sql');
+  final summariesSql =
+      await rootBundle.loadString('assets/sql/migrations/004_add_summaries.sql');
+  final keywordsSql =
+      await rootBundle.loadString('assets/sql/migrations/005_add_keywords.sql');
+  final documentKeywordsSql = await rootBundle.loadString(
+      'assets/sql/migrations/006_add_document_keywords.sql');
+  final embeddingsSql =
+      await rootBundle.loadString('assets/sql/migrations/007_add_embeddings.sql');
+  final documentsFtsSql = await rootBundle
+      .loadString('assets/sql/migrations/008_add_documents_fts.sql');
+
+  return <Migration>[
+    Migration(name: '001_init_core_schema', sql: initSql),
+    Migration(name: '002_add_places', sql: placesSql),
+    Migration(name: '003_add_documents_and_pages', sql: documentsAndPagesSql),
+    Migration(name: '004_add_summaries', sql: summariesSql),
+    Migration(name: '005_add_keywords', sql: keywordsSql),
+    Migration(name: '006_add_document_keywords', sql: documentKeywordsSql),
+    Migration(name: '007_add_embeddings', sql: embeddingsSql),
+    Migration(name: '008_add_documents_fts', sql: documentsFtsSql),
+  ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SqlitePlaceRepository', () {
+    late MigrationDb db;
+    late SqlitePlaceRepository repo;
+
+    setUp(() async {
+      final rawDb = sqlite.sqlite3.openInMemory();
+      db = Sqlite3MigrationDb(rawDb);
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+      await runner.runAll();
+      repo = SqlitePlaceRepository(db);
+    });
+
+    test('getOrCreate returns new place with correct name and timestamps',
+        () async {
+      final place = await repo.getOrCreate('Banking');
+      expect(place.name, 'Banking');
+      expect(place.id, isNotEmpty);
+      expect(place.description, isNull);
+      expect(place.createdAt, isNotNull);
+      expect(place.updatedAt, isNotNull);
+    });
+
+    test('getOrCreate with same name returns same place (reuse)', () async {
+      final p1 = await repo.getOrCreate('University');
+      final p2 = await repo.getOrCreate('University');
+      expect(p2.id, p1.id);
+      expect(p2.name, p1.name);
+    });
+
+    test('listAll returns places in stable order by name', () async {
+      await repo.getOrCreate('Zebra');
+      await repo.getOrCreate('Alpha');
+      await repo.getOrCreate('Middle');
+
+      final all = await repo.listAll();
+      expect(all.length, 3);
+      expect(all[0].name, 'Alpha');
+      expect(all[1].name, 'Middle');
+      expect(all[2].name, 'Zebra');
+    });
+  });
+}


### PR DESCRIPTION
## What changed

- Added `Place` entity and `PlaceRepository` in the domain layer.
- Implemented `SqlitePlaceRepository` with `getOrCreate(name)` and `listAll()` (ordered by name). Name normalization: trim only; case-sensitive to match SQLite `UNIQUE`.
- Unit tests for creation, reuse, and listing order.
- Integration tests: document ↔ place reference and referential integrity (FK on invalid `place_id`, ON DELETE RESTRICT when a place is still referenced).

## Why

Places are the main way we organize documents, but there was no repository for them; callers would have had to use raw SQL. This adds a clear abstraction and keeps storage details in the infra layer.

## How to test

- `flutter test test/infrastructure/sqlite/sqlite_place_repository_test.dart`
- `flutter test test/infrastructure/sqlite/sqlite_place_repository_integration_test.dart`

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (name normalization in class doc)
- [x] Linter/Formatter passes
- [x] No debug logs or TODOs left in code