### PR TITLE
Feat/implement sqlite embedding repository optional

### DIFF
--- a/lib/infrastructure/sqlite/sqlite_embedding_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_embedding_repository.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart'
+    show MigrationDb;
+import 'package:personal_archive/src/domain/domain.dart';
+
+/// SQLite-backed implementation of [EmbeddingRepository].
+///
+/// Stores [Embedding.vector] as TEXT containing a JSON array of doubles.
+/// Stores [Embedding.createdAt] as Unix epoch milliseconds (INTEGER) in UTC
+/// when present; otherwise NULL.
+class SqliteEmbeddingRepository implements EmbeddingRepository {
+  SqliteEmbeddingRepository(this._db);
+
+  final MigrationDb _db;
+
+  static int _toEpochMillis(DateTime dateTime) {
+    return dateTime.toUtc().millisecondsSinceEpoch;
+  }
+
+  static DateTime? _fromEpochMillis(Object? value) {
+    if (value == null) return null;
+    final millis = value as int;
+    return DateTime.fromMillisecondsSinceEpoch(millis, isUtc: true);
+  }
+
+  static String _vectorToJson(List<double> vector) {
+    return jsonEncode(vector);
+  }
+
+  static List<double> _jsonToVector(String json) {
+    final decoded = jsonDecode(json) as List<dynamic>;
+    return decoded.map((e) => (e as num).toDouble()).toList();
+  }
+
+  static Embedding _rowToEmbedding(Map<String, Object?> row) {
+    final createdAt = _fromEpochMillis(row['created_at']);
+    final vectorJson = row['vector'] as String;
+    return Embedding(
+      documentId: row['document_id'] as String,
+      vector: _jsonToVector(vectorJson),
+      modelVersion: row['model_version'] as String?,
+      createdAt: createdAt,
+    );
+  }
+
+  static Never _handleError(Object e) {
+    final msg = e.toString().toLowerCase();
+    if (msg.contains('foreign key') ||
+        msg.contains('constraint') ||
+        msg.contains('sqlite_constraint')) {
+      throw StorageConstraintError(detail: e.toString());
+    }
+    throw StorageUnknownError(e);
+  }
+
+  @override
+  Future<void> upsert(Embedding embedding) async {
+    try {
+      await _db.execute(
+        '''
+        INSERT OR REPLACE INTO embeddings (
+          document_id,
+          vector,
+          model_version,
+          created_at
+        ) VALUES (?, ?, ?, ?)
+        ''',
+        [
+          embedding.documentId,
+          _vectorToJson(embedding.vector),
+          embedding.modelVersion,
+          embedding.createdAt != null ? _toEpochMillis(embedding.createdAt!) : null,
+        ],
+      );
+    } catch (e) {
+      _handleError(e);
+    }
+  }
+
+  @override
+  Future<Embedding?> findByDocumentId(String documentId) async {
+    try {
+      final rows = await _db.query(
+        'SELECT * FROM embeddings WHERE document_id = ?',
+        [documentId],
+      );
+      if (rows.isEmpty) return null;
+      return _rowToEmbedding(rows.single);
+    } catch (e) {
+      _handleError(e);
+    }
+  }
+}
+

--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -3,6 +3,8 @@ export 'document.dart';
 export 'document_keyword_relation.dart';
 export 'document_keyword_repository.dart';
 export 'document_repository.dart';
+export 'embedding.dart';
+export 'embedding_repository.dart';
 export 'keyword.dart';
 export 'keyword_repository.dart';
 export 'page.dart';

--- a/lib/src/domain/embedding.dart
+++ b/lib/src/domain/embedding.dart
@@ -1,0 +1,29 @@
+/// Represents a semantic embedding for a document (1:1 with document).
+class Embedding {
+  const Embedding({
+    required this.documentId,
+    required this.vector,
+    this.modelVersion,
+    this.createdAt,
+  });
+
+  final String documentId;
+  final List<double> vector;
+  final String? modelVersion;
+  final DateTime? createdAt;
+
+  Embedding copyWith({
+    String? documentId,
+    List<double>? vector,
+    String? modelVersion,
+    DateTime? createdAt,
+  }) {
+    return Embedding(
+      documentId: documentId ?? this.documentId,
+      vector: vector ?? this.vector,
+      modelVersion: modelVersion ?? this.modelVersion,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}
+

--- a/lib/src/domain/embedding_repository.dart
+++ b/lib/src/domain/embedding_repository.dart
@@ -1,0 +1,13 @@
+import 'embedding.dart';
+import 'storage_error.dart';
+
+/// Persistence contract for [Embedding] entities (1:1 with document).
+abstract class EmbeddingRepository {
+  /// Inserts or updates [embedding] by [Embedding.documentId].
+  /// Throws [StorageError] on failure (e.g. foreign key violation).
+  Future<void> upsert(Embedding embedding);
+
+  /// Returns the embedding for the given [documentId], or null if none exists.
+  Future<Embedding?> findByDocumentId(String documentId);
+}
+

--- a/test/infrastructure/sqlite/sqlite_embedding_repository_integration_test.dart
+++ b/test/infrastructure/sqlite/sqlite_embedding_repository_integration_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_embedding_repository.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+class Sqlite3MigrationDb implements MigrationDb {
+  Sqlite3MigrationDb(this._db) {
+    _db.execute('PRAGMA foreign_keys = ON');
+  }
+
+  final sqlite.Database _db;
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) async {
+    _db.execute(sql, parameters);
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> query(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = _db.select(sql, parameters);
+    return result
+        .map<Map<String, Object?>>((row) => Map<String, Object?>.from(row))
+        .toList();
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function() action) async {
+    _db.execute('BEGIN');
+    try {
+      final result = await action();
+      _db.execute('COMMIT');
+      return result;
+    } catch (e) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
+  }
+}
+
+Future<List<Migration>> _loadTestMigrations() async {
+  final initSql =
+      await rootBundle.loadString('assets/sql/migrations/001_init_core_schema.sql');
+  final placesSql =
+      await rootBundle.loadString('assets/sql/migrations/002_add_places.sql');
+  final documentsAndPagesSql = await rootBundle
+      .loadString('assets/sql/migrations/003_add_documents_and_pages.sql');
+  final summariesSql =
+      await rootBundle.loadString('assets/sql/migrations/004_add_summaries.sql');
+  final keywordsSql =
+      await rootBundle.loadString('assets/sql/migrations/005_add_keywords.sql');
+  final documentKeywordsSql = await rootBundle.loadString(
+      'assets/sql/migrations/006_add_document_keywords.sql');
+  final embeddingsSql =
+      await rootBundle.loadString('assets/sql/migrations/007_add_embeddings.sql');
+  final documentsFtsSql =
+      await rootBundle.loadString('assets/sql/migrations/008_add_documents_fts.sql');
+
+  return <Migration>[
+    Migration(name: '001_init_core_schema', sql: initSql),
+    Migration(name: '002_add_places', sql: placesSql),
+    Migration(name: '003_add_documents_and_pages', sql: documentsAndPagesSql),
+    Migration(name: '004_add_summaries', sql: summariesSql),
+    Migration(name: '005_add_keywords', sql: keywordsSql),
+    Migration(name: '006_add_document_keywords', sql: documentKeywordsSql),
+    Migration(name: '007_add_embeddings', sql: embeddingsSql),
+    Migration(name: '008_add_documents_fts', sql: documentsFtsSql),
+  ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SqliteEmbeddingRepository integration', () {
+    late MigrationDb db;
+    late SqliteEmbeddingRepository repo;
+
+    setUp(() async {
+      final rawDb = sqlite.sqlite3.openInMemory();
+      db = Sqlite3MigrationDb(rawDb);
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+      await runner.runAll();
+      repo = SqliteEmbeddingRepository(db);
+    });
+
+    test(
+      'full migration + insert document + upsert embedding + findByDocumentId returns embedding',
+      () async {
+        const documentId = 'doc-full-embedding-cycle';
+        final now = DateTime.utc(2025, 2, 19, 14, 30, 0);
+        final epoch = now.millisecondsSinceEpoch;
+
+        await db.execute(
+          '''
+          INSERT INTO documents (
+            id, title, file_path, status, confidence_score,
+            place_id, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          ''',
+          [
+            documentId,
+            'Full Cycle Doc',
+            '/path/full.pdf',
+            DocumentStatus.imported.name,
+            0.85,
+            null,
+            epoch,
+            epoch,
+          ],
+        );
+
+        final embedding = Embedding(
+          documentId: documentId,
+          vector: <double>[0.1, -0.2, 0.3, 0.4],
+          modelVersion: 'embed-model-v1',
+          createdAt: now,
+        );
+        await repo.upsert(embedding);
+
+        final found = await repo.findByDocumentId(documentId);
+        expect(found, isNotNull);
+        expect(found!.documentId, documentId);
+        expect(found.vector, <double>[0.1, -0.2, 0.3, 0.4]);
+        expect(found.modelVersion, 'embed-model-v1');
+        expect(found.createdAt, now);
+      },
+    );
+
+    test('upsert with non-existent documentId throws StorageConstraintError',
+        () async {
+      final embedding = Embedding(
+        documentId: 'non-existent-doc',
+        vector: <double>[0.5, 0.6],
+        modelVersion: 'embed-model-v1',
+        createdAt: DateTime.utc(2025, 2, 19),
+      );
+
+      expect(
+        () => repo.upsert(embedding),
+        throwsA(isA<StorageConstraintError>()),
+      );
+    });
+
+    test('findByDocumentId for document with no embedding returns null',
+        () async {
+      const documentId = 'doc-no-embedding';
+      final epoch = DateTime.utc(2025, 2, 19).millisecondsSinceEpoch;
+
+      await db.execute(
+        '''
+        INSERT INTO documents (
+          id, title, file_path, status, confidence_score,
+          place_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        [
+          documentId,
+          'Doc Without Embedding',
+          '/path/nosummary.pdf',
+          DocumentStatus.imported.name,
+          null,
+          null,
+          epoch,
+          epoch,
+        ],
+      );
+
+      final result = await repo.findByDocumentId(documentId);
+
+      expect(result, isNull);
+    });
+  });
+}
+

--- a/test/infrastructure/sqlite/sqlite_embedding_repository_test.dart
+++ b/test/infrastructure/sqlite/sqlite_embedding_repository_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_embedding_repository.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+class Sqlite3MigrationDb implements MigrationDb {
+  Sqlite3MigrationDb(this._db) {
+    _db.execute('PRAGMA foreign_keys = ON');
+  }
+
+  final sqlite.Database _db;
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) async {
+    _db.execute(sql, parameters);
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> query(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = _db.select(sql, parameters);
+    return result
+        .map<Map<String, Object?>>((row) => Map<String, Object?>.from(row))
+        .toList();
+  }
+
+  @override
+  Future<T> transaction<T>(Future<T> Function() action) async {
+    _db.execute('BEGIN');
+    try {
+      final result = await action();
+      _db.execute('COMMIT');
+      return result;
+    } catch (e) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
+  }
+}
+
+Future<List<Migration>> _loadTestMigrations() async {
+  final initSql =
+      await rootBundle.loadString('assets/sql/migrations/001_init_core_schema.sql');
+  final placesSql =
+      await rootBundle.loadString('assets/sql/migrations/002_add_places.sql');
+  final documentsAndPagesSql = await rootBundle
+      .loadString('assets/sql/migrations/003_add_documents_and_pages.sql');
+  final summariesSql =
+      await rootBundle.loadString('assets/sql/migrations/004_add_summaries.sql');
+  final keywordsSql =
+      await rootBundle.loadString('assets/sql/migrations/005_add_keywords.sql');
+  final documentKeywordsSql = await rootBundle.loadString(
+      'assets/sql/migrations/006_add_document_keywords.sql');
+  final embeddingsSql =
+      await rootBundle.loadString('assets/sql/migrations/007_add_embeddings.sql');
+  final documentsFtsSql =
+      await rootBundle.loadString('assets/sql/migrations/008_add_documents_fts.sql');
+
+  return <Migration>[
+    Migration(name: '001_init_core_schema', sql: initSql),
+    Migration(name: '002_add_places', sql: placesSql),
+    Migration(name: '003_add_documents_and_pages', sql: documentsAndPagesSql),
+    Migration(name: '004_add_summaries', sql: summariesSql),
+    Migration(name: '005_add_keywords', sql: keywordsSql),
+    Migration(name: '006_add_document_keywords', sql: documentKeywordsSql),
+    Migration(name: '007_add_embeddings', sql: embeddingsSql),
+    Migration(name: '008_add_documents_fts', sql: documentsFtsSql),
+  ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SqliteEmbeddingRepository', () {
+    late MigrationDb db;
+    late SqliteEmbeddingRepository repo;
+
+    setUp(() async {
+      final rawDb = sqlite.sqlite3.openInMemory();
+      db = Sqlite3MigrationDb(rawDb);
+      final runner = MigrationRunner(
+        db: db,
+        loadMigrations: _loadTestMigrations,
+      );
+      await runner.runAll();
+      repo = SqliteEmbeddingRepository(db);
+    });
+
+    test('upsert then findByDocumentId returns embedding with correct fields',
+        () async {
+      const documentId = 'doc-with-embedding';
+
+      await db.execute(
+        '''
+        INSERT INTO documents (
+          id, title, file_path, status, confidence_score,
+          place_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        [
+          documentId,
+          'Doc Title',
+          '/path/to/doc.pdf',
+          DocumentStatus.imported.name,
+          0.9,
+          null,
+          0,
+          0,
+        ],
+      );
+
+      final createdAt = DateTime.utc(2025, 2, 19, 12, 0, 0);
+      final embedding = Embedding(
+        documentId: documentId,
+        vector: <double>[0.1, -0.2, 0.3],
+        modelVersion: 'embed-model-v1',
+        createdAt: createdAt,
+      );
+
+      await repo.upsert(embedding);
+
+      final found = await repo.findByDocumentId(documentId);
+      expect(found, isNotNull);
+      expect(found!.documentId, documentId);
+      expect(found.vector, <double>[0.1, -0.2, 0.3]);
+      expect(found.modelVersion, 'embed-model-v1');
+      expect(found.createdAt, createdAt);
+    });
+
+    test('findByDocumentId returns null when document has no embedding',
+        () async {
+      const documentId = 'doc-no-embedding';
+
+      await db.execute(
+        '''
+        INSERT INTO documents (
+          id, title, file_path, status, confidence_score,
+          place_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''',
+        [
+          documentId,
+          'Doc Without Embedding',
+          '/path/to/other.pdf',
+          DocumentStatus.imported.name,
+          null,
+          null,
+          0,
+          0,
+        ],
+      );
+
+      final found = await repo.findByDocumentId(documentId);
+      expect(found, isNull);
+    });
+  });
+}
+


### PR DESCRIPTION
## What changed

- Added `Embedding` domain model and `EmbeddingRepository` abstraction for 1:1 document embeddings.
- Implemented `SqliteEmbeddingRepository` to persist embeddings in the `embeddings` table, storing vectors as TEXT/JSON and timestamps as epoch millis.
- Added unit tests for `SqliteEmbeddingRepository` to verify round‑trip persistence and the “no embedding” case.
- Added integration tests to run full migrations, insert documents, upsert embeddings, and confirm retrieval + FK constraints behave as expected.

## Why it changed

Issue 13 adds a proper repository abstraction for the existing `embeddings` table so early semantic search experiments can use embeddings without reaching into raw SQL. This keeps the storage format decision (TEXT/JSON) encapsulated and aligns embeddings with the existing clean-architecture repository pattern used for summaries and other entities.

## How to test

- Run all tests (recommended):

## Checklist
- [x] Tests added/updated
- [x] Linter/formatter passes
- [x] No debug logs or stray TODOs
- [x] Documentation updated if we add more semantics around embedding usage later
  