### PR TITLE
Feat/14 add storage layer logging and metrics hooks

### DIFF
--- a/docs/storage_logging.md
+++ b/docs/storage_logging.md
@@ -1,0 +1,139 @@
+# Storage-Layer Logging & Metrics Hooks
+
+The storage layer uses a small, pluggable logging abstraction to make important SQLite operations observable without coupling repositories to a specific logging framework.
+
+This document describes what is logged, how it works, and how to configure it in development.
+
+---
+
+## Overview
+
+Storage observability focuses on three areas:
+
+- **Repository writes**: inserts, updates, and bulk operations that change data.
+- **Slow reads**: queries that exceed a configurable latency threshold.
+- **Migrations**: the lifecycle of schema migrations, including success and failure.
+
+All of this is wired through `StorageLogger` in the SQLite infrastructure layer.
+
+---
+
+## StorageLogger abstraction
+
+The core interface lives in `lib/infrastructure/sqlite/storage_logging.dart`:
+
+- **`StorageLogger`**: defines
+  - `logWrite(operation, table, recordCount, duration)`
+  - `logRead(operation, table, duration)`
+- **`NoOpStorageLogger`**: a default implementation that does nothing; used when logging is not configured.
+- **Timing helpers**:
+  - `timeWriteOperation` wraps an async write and reports its duration via `logWrite`.
+  - `timeReadOperation` wraps an async read and, if it exceeds a threshold, reports its duration via `logRead`.
+
+These helpers are used by repositories and the migration runner so that instrumentation is centralized and consistent.
+
+---
+
+## Repository logging behavior
+
+Each SQLite-backed repository accepts an optional `StorageLogger` and a `slowReadThreshold`:
+
+- Constructors have the shape:
+  - `SqliteXRepository(MigrationDb db, { StorageLogger logger = const NoOpStorageLogger(), Duration slowReadThreshold = const Duration(milliseconds: 75), })`
+- **Write operations** (such as `upsert`, `create`, bulk `insertAll`) are wrapped in `timeWriteOperation`, which logs:
+  - `operation`: a short, descriptive operation name (e.g. `create_document`, `upsert_summary`).
+  - `table`: the primary table being modified (e.g. `documents`, `summaries`).
+  - `recordCount`: number of rows affected or attempted.
+  - `duration`: how long the operation took.
+- **Read operations** that are likely to be performance-sensitive are wrapped in `timeReadOperation`, which:
+  - Measures query duration.
+  - Emits a `logRead` event only when `duration >= slowReadThreshold`.
+
+In development you can:
+
+- Provide a concrete `StorageLogger` that prints to the console or forwards to a logging package.
+- Lower `slowReadThreshold` (even to `Duration.zero`) to surface all reads while debugging.
+
+---
+
+## Migration logging behavior
+
+`MigrationRunner` in `lib/infrastructure/sqlite/migrations/migration_runner.dart` also accepts an optional `StorageLogger`:
+
+- Constructor:
+  - `MigrationRunner({ required MigrationDb db, required Future<List<Migration>> Function() loadMigrations, StorageLogger logger = const NoOpStorageLogger(), })`
+- For each unapplied migration, the runner:
+  - Logs a **start** event: `migration_start:<name>`.
+  - Uses `timeWriteOperation` to:
+    - Apply the migration SQL to the database.
+    - Record the migration in `schema_migrations`.
+  - On success, logs a **success** event: `migration_success:<name>` with the end-to-end duration.
+  - On error, logs a **failure** event: `migration_error:<name>` with the elapsed time, then rethrows so the transaction can roll back.
+
+This makes it easier to see which migration failed and roughly how long each one took.
+
+---
+
+## Development usage
+
+To observe storage behavior during development:
+
+1. **Implement a simple logger**, for example in your application layer:
+
+   ```dart
+   class ConsoleStorageLogger implements StorageLogger {
+     @override
+     void logWrite({
+       required String operation,
+       required String table,
+       required int recordCount,
+       required Duration duration,
+     }) {
+       // Replace with your preferred logging framework if needed.
+       // e.g. debugPrint or package:logging.
+       // debugPrint('[WRITE] $operation table=$table count=$recordCount duration=${duration.inMilliseconds}ms');
+     }
+
+     @override
+     void logRead({
+       required String operation,
+       required String table,
+       required Duration duration,
+     }) {
+       // debugPrint('[READ] $operation table=$table duration=${duration.inMilliseconds}ms');
+     }
+   }
+   ```
+
+2. **Pass the logger into infrastructure components** when wiring them up:
+
+   ```dart
+   final storageLogger = ConsoleStorageLogger();
+
+   final documentRepo = SqliteDocumentRepository(
+     migrationDb,
+     logger: storageLogger,
+   );
+
+   final migrationRunner = MigrationRunner(
+     db: migrationDb,
+     loadMigrations: loadMigrations,
+     logger: storageLogger,
+   );
+   ```
+
+3. **Tune the slow-read threshold** when investigating performance:
+   - Use a lower threshold (or `Duration.zero`) to log all reads.
+   - Use a higher threshold in normal runs to focus only on outliers.
+
+---
+
+## Testing guarantees
+
+There are tests under `test/infrastructure/sqlite` that verify:
+
+- Enabling storage logging on `MigrationRunner` does **not** prevent migrations from succeeding.
+- Enabling storage logging on `SqliteSummaryRepository` (with a custom logger and `slowReadThreshold: Duration.zero`) preserves repository behavior and records both write and read events.
+
+These tests ensure that the logging layer is safe to enable and does not change storage semantics.
+

--- a/lib/infrastructure/sqlite/sqlite_document_keyword_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_document_keyword_repository.dart
@@ -10,10 +10,13 @@ class SqliteDocumentKeywordRepository implements DocumentKeywordRepository {
   SqliteDocumentKeywordRepository(
     this._db, {
     StorageLogger logger = const NoOpStorageLogger(),
-  }) : _logger = logger;
+    Duration slowReadThreshold = const Duration(milliseconds: 75),
+  })  : _logger = logger,
+        _slowReadThreshold = slowReadThreshold;
 
   final MigrationDb _db;
   final StorageLogger _logger;
+  final Duration _slowReadThreshold;
 
   static Keyword _rowToKeyword(Map<String, Object?> row) {
     final createdMillis = row['created_at'] as int;
@@ -82,19 +85,25 @@ class SqliteDocumentKeywordRepository implements DocumentKeywordRepository {
   @override
   Future<List<Keyword>> listForDocument(String documentId) async {
     try {
-      final rows = await _db.query(
-        '''
-        SELECT
-          k.id AS id,
-          k.value AS value,
-          k.type AS type,
-          k.global_frequency AS global_frequency,
-          k.created_at AS created_at
-        FROM document_keywords dk
-        JOIN keywords k ON dk.keyword_id = k.id
-        WHERE dk.document_id = ?
-        ''',
-        [documentId],
+      final rows = await timeReadOperation<List<Map<String, Object?>>>(
+        logger: _logger,
+        operation: 'list_keywords_for_document',
+        table: 'document_keywords',
+        slowLogThreshold: _slowReadThreshold,
+        action: () => _db.query(
+          '''
+          SELECT
+            k.id AS id,
+            k.value AS value,
+            k.type AS type,
+            k.global_frequency AS global_frequency,
+            k.created_at AS created_at
+          FROM document_keywords dk
+          JOIN keywords k ON dk.keyword_id = k.id
+          WHERE dk.document_id = ?
+          ''',
+          [documentId],
+        ),
       );
       return rows.map(_rowToKeyword).toList();
     } catch (e) {

--- a/lib/infrastructure/sqlite/sqlite_embedding_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_embedding_repository.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart'
     show MigrationDb;
+import 'package:personal_archive/infrastructure/sqlite/storage_logging.dart';
 import 'package:personal_archive/src/domain/domain.dart';
 
 /// SQLite-backed implementation of [EmbeddingRepository].
@@ -10,9 +11,13 @@ import 'package:personal_archive/src/domain/domain.dart';
 /// Stores [Embedding.createdAt] as Unix epoch milliseconds (INTEGER) in UTC
 /// when present; otherwise NULL.
 class SqliteEmbeddingRepository implements EmbeddingRepository {
-  SqliteEmbeddingRepository(this._db);
+  SqliteEmbeddingRepository(
+    this._db, {
+    StorageLogger logger = const NoOpStorageLogger(),
+  }) : _logger = logger;
 
   final MigrationDb _db;
+  final StorageLogger _logger;
 
   static int _toEpochMillis(DateTime dateTime) {
     return dateTime.toUtc().millisecondsSinceEpoch;
@@ -57,21 +62,29 @@ class SqliteEmbeddingRepository implements EmbeddingRepository {
   @override
   Future<void> upsert(Embedding embedding) async {
     try {
-      await _db.execute(
-        '''
-        INSERT OR REPLACE INTO embeddings (
-          document_id,
-          vector,
-          model_version,
-          created_at
-        ) VALUES (?, ?, ?, ?)
-        ''',
-        [
-          embedding.documentId,
-          _vectorToJson(embedding.vector),
-          embedding.modelVersion,
-          embedding.createdAt != null ? _toEpochMillis(embedding.createdAt!) : null,
-        ],
+      await timeWriteOperation<void>(
+        logger: _logger,
+        operation: 'upsert_embedding',
+        table: 'embeddings',
+        recordCount: 1,
+        action: () => _db.execute(
+          '''
+          INSERT OR REPLACE INTO embeddings (
+            document_id,
+            vector,
+            model_version,
+            created_at
+          ) VALUES (?, ?, ?, ?)
+          ''',
+          [
+            embedding.documentId,
+            _vectorToJson(embedding.vector),
+            embedding.modelVersion,
+            embedding.createdAt != null
+                ? _toEpochMillis(embedding.createdAt!)
+                : null,
+          ],
+        ),
       );
     } catch (e) {
       _handleError(e);

--- a/lib/infrastructure/sqlite/sqlite_keyword_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_keyword_repository.dart
@@ -12,10 +12,13 @@ class SqliteKeywordRepository implements KeywordRepository {
   SqliteKeywordRepository(
     this._db, {
     StorageLogger logger = const NoOpStorageLogger(),
-  }) : _logger = logger;
+    Duration slowReadThreshold = const Duration(milliseconds: 75),
+  })  : _logger = logger,
+        _slowReadThreshold = slowReadThreshold;
 
   final MigrationDb _db;
   final StorageLogger _logger;
+  final Duration _slowReadThreshold;
   static final Random _random = Random();
 
   static int _toEpochMillis(DateTime dateTime) {
@@ -55,9 +58,15 @@ class SqliteKeywordRepository implements KeywordRepository {
   @override
   Future<Keyword> getOrCreate(String value, String type) async {
     try {
-      final rows = await _db.query(
-        'SELECT * FROM keywords WHERE value = ? AND type = ?',
-        [value, type],
+      final rows = await timeReadOperation<List<Map<String, Object?>>>(
+        logger: _logger,
+        operation: 'get_or_create_keyword_lookup',
+        table: 'keywords',
+        slowLogThreshold: _slowReadThreshold,
+        action: () => _db.query(
+          'SELECT * FROM keywords WHERE value = ? AND type = ?',
+          [value, type],
+        ),
       );
       if (rows.isNotEmpty) return _rowToKeyword(rows.single);
 

--- a/lib/infrastructure/sqlite/storage_logging.dart
+++ b/lib/infrastructure/sqlite/storage_logging.dart
@@ -1,0 +1,109 @@
+/// Logging and timing utilities for the storage layer.
+///
+/// This abstraction is intentionally minimal and pluggable so that
+/// it can later be wired to a more fully featured logging or metrics
+/// backend without changing repository and migration code.
+abstract class StorageLogger {
+  /// Records a write operation against a storage table.
+  ///
+  /// Implementations are expected to log or emit metrics using the
+  /// provided metadata. [recordCount] should represent the number of
+  /// rows affected or attempted by the operation.
+  void logWrite({
+    required String operation,
+    required String table,
+    required int recordCount,
+    required Duration duration,
+  });
+
+  /// Records a read operation against a storage table.
+  ///
+  /// Implementations may choose to emit all read events or only a
+  /// subset (for example, slow reads) depending on configuration.
+  void logRead({
+    required String operation,
+    required String table,
+    required Duration duration,
+  });
+}
+
+/// No-op implementation used when storage logging is not configured.
+///
+/// This allows repositories and the migration runner to depend on
+/// [StorageLogger] without forcing a concrete logger in every
+/// environment.
+class NoOpStorageLogger implements StorageLogger {
+  const NoOpStorageLogger();
+
+  @override
+  void logWrite({
+    required String operation,
+    required String table,
+    required int recordCount,
+    required Duration duration,
+  }) {
+    // Intentionally empty.
+  }
+
+  @override
+  void logRead({
+    required String operation,
+    required String table,
+    required Duration duration,
+  }) {
+    // Intentionally empty.
+  }
+}
+
+typedef _AsyncOperation<T> = Future<T> Function();
+
+/// Measures the duration of a write operation and reports it via [logger].
+///
+/// The wrapped [action] is awaited and its result is returned. The logger
+/// is notified regardless of whether [action] completes successfully or
+/// throws.
+Future<T> timeWriteOperation<T>({
+  required StorageLogger logger,
+  required String operation,
+  required String table,
+  required int recordCount,
+  required _AsyncOperation<T> action,
+}) async {
+  final stopwatch = Stopwatch()..start();
+  try {
+    return await action();
+  } finally {
+    stopwatch.stop();
+    logger.logWrite(
+      operation: operation,
+      table: table,
+      recordCount: recordCount,
+      duration: stopwatch.elapsed,
+    );
+  }
+}
+
+/// Measures the duration of a read operation and reports it via [logger].
+///
+/// The wrapped [action] is awaited and its result is returned. The logger
+/// is notified regardless of whether [action] completes successfully or
+/// throws.
+Future<T> timeReadOperation<T>({
+  required StorageLogger logger,
+  required String operation,
+  required String table,
+  required _AsyncOperation<T> action,
+}) async {
+  final stopwatch = Stopwatch()..start();
+  try {
+    return await action();
+  } finally {
+    stopwatch.stop();
+    logger.logRead(
+      operation: operation,
+      table: table,
+      duration: stopwatch.elapsed,
+    );
+  }
+}
+

--- a/lib/infrastructure/sqlite/storage_logging.dart
+++ b/lib/infrastructure/sqlite/storage_logging.dart
@@ -92,6 +92,7 @@ Future<T> timeReadOperation<T>({
   required StorageLogger logger,
   required String operation,
   required String table,
+  Duration slowLogThreshold = const Duration(milliseconds: 75),
   required _AsyncOperation<T> action,
 }) async {
   final stopwatch = Stopwatch()..start();
@@ -99,11 +100,14 @@ Future<T> timeReadOperation<T>({
     return await action();
   } finally {
     stopwatch.stop();
-    logger.logRead(
-      operation: operation,
-      table: table,
-      duration: stopwatch.elapsed,
-    );
+    final duration = stopwatch.elapsed;
+    if (duration >= slowLogThreshold) {
+      logger.logRead(
+        operation: operation,
+        table: table,
+        duration: duration,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## What changed

- Added a minimal, pluggable `StorageLogger` abstraction and timing helpers in the SQLite infrastructure layer.
- Instrumented all SQLite repositories to log write operations (with operation name, table, record count, and duration) and slow reads over a configurable threshold.
- Updated `MigrationRunner` to emit migration lifecycle events (start, success, error) and to time both the SQL execution and `schema_migrations` bookkeeping.
- Added tests to ensure enabling storage logging does not change repository or migration behavior, and added `docs/storage_logging.md` explaining how the logging layer works and how to configure it.

## Why it changed

Issue 14 calls for observability in the storage layer so that slow queries, failed migrations, and storage behavior are visible without leaking logging concerns into domain logic. This PR introduces a small, infrastructure-level abstraction that can later be wired to a real logger/metrics backend while keeping the rest of the system decoupled.

## How to test

- Run the existing SQLite tests, including:
  - `flutter test test/infrastructure/sqlite/migrations/migration_runner_test.dart`
  - `flutter test test/infrastructure/sqlite/sqlite_summary_repository_test.dart`
- Optionally, wire a simple `StorageLogger` implementation in the application wiring, set a low `slowReadThreshold`, and exercise typical repository flows to see write and slow-read logs in the console.
- Run migrations end-to-end (via the app or a small harness) and verify migration start/success/error events are logged.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (`docs/storage_logging.md`)
- [x] Linter/formatter passes
- [x] No debug logs or stray TODOs left in code