### PR TITLE
Test/add storage layer integration tests for end to end flows

### DIFF
--- a/test/infrastructure/sqlite/sqlite_storage_integration_harness.dart
+++ b/test/infrastructure/sqlite/sqlite_storage_integration_harness.dart
@@ -1,0 +1,54 @@
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart'
+    show MigrationDb;
+import 'package:personal_archive/infrastructure/sqlite/sqlite_document_keyword_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_document_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_embedding_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_keyword_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_page_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_place_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_summary_repository.dart';
+
+import 'sqlite_test_harness.dart';
+
+/// Aggregates a migrated SQLite database and all storage-layer repositories
+/// used in end-to-end integration tests.
+class StorageIntegrationContext {
+  StorageIntegrationContext({
+    required this.db,
+    required this.documentRepository,
+    required this.placeRepository,
+    required this.pageRepository,
+    required this.summaryRepository,
+    required this.keywordRepository,
+    required this.documentKeywordRepository,
+    required this.embeddingRepository,
+  });
+
+  final MigrationDb db;
+  final SqliteDocumentRepository documentRepository;
+  final SqlitePlaceRepository placeRepository;
+  final SqlitePageRepository pageRepository;
+  final SqliteSummaryRepository summaryRepository;
+  final SqliteKeywordRepository keywordRepository;
+  final SqliteDocumentKeywordRepository documentKeywordRepository;
+  final SqliteEmbeddingRepository embeddingRepository;
+}
+
+/// Creates a fresh in-memory SQLite database, runs all migrations, and
+/// constructs repository instances wired to that database for use in
+/// storage-layer end-to-end integration tests.
+Future<StorageIntegrationContext> createStorageIntegrationContext() async {
+  final db = await createMigratedTestDb();
+
+  return StorageIntegrationContext(
+    db: db,
+    documentRepository: SqliteDocumentRepository(db),
+    placeRepository: SqlitePlaceRepository(db),
+    pageRepository: SqlitePageRepository(db),
+    summaryRepository: SqliteSummaryRepository(db),
+    keywordRepository: SqliteKeywordRepository(db),
+    documentKeywordRepository: SqliteDocumentKeywordRepository(db),
+    embeddingRepository: SqliteEmbeddingRepository(db),
+  );
+}
+

--- a/test/infrastructure/sqlite/sqlite_storage_integration_test.dart
+++ b/test/infrastructure/sqlite/sqlite_storage_integration_test.dart
@@ -225,6 +225,24 @@ void main() {
         expect(completedArchiveMidIds, ['filter-doc-3']);
       },
     );
+
+    test(
+      'summary upsert fails for non-existent documentId (FK constraint)',
+      () async {
+        final now = DateTime.utc(2025, 2, 19, 15, 0, 0);
+        final summary = Summary(
+          documentId: 'missing-doc-id',
+          text: 'Should not be stored',
+          modelVersion: 'qwen2.5-0.5b',
+          createdAt: now,
+        );
+
+        expect(
+          () => ctx.summaryRepository.upsert(summary),
+          throwsA(isA<StorageConstraintError>()),
+        );
+      },
+    );
   });
 }
 

--- a/test/infrastructure/sqlite/sqlite_storage_integration_test.dart
+++ b/test/infrastructure/sqlite/sqlite_storage_integration_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+
+import 'sqlite_storage_integration_harness.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Storage integration end-to-end', () {
+    late StorageIntegrationContext ctx;
+
+    setUp(() async {
+      ctx = await createStorageIntegrationContext();
+    });
+
+    test(
+      'full flow: document + place + pages + summary + keywords + embedding round-trip',
+      () async {
+        // Arrange: create a place.
+        final place = await ctx.placeRepository.getOrCreate('Archive');
+        final now = DateTime.utc(2025, 2, 19, 12, 0, 0);
+
+        // Document referencing the place.
+        final document = Document(
+          id: 'e2e-doc-1',
+          title: 'End-to-End Storage Doc',
+          filePath: '/path/e2e.pdf',
+          status: DocumentStatus.completed,
+          confidenceScore: 0.95,
+          createdAt: now,
+          updatedAt: now,
+          placeId: place.id,
+        );
+        await ctx.documentRepository.create(document);
+
+        // Pages for the document.
+        final pages = <Page>[
+          Page(
+            id: 'e2e-page-1',
+            documentId: document.id,
+            pageNumber: 1,
+            rawText: 'raw one',
+            processedText: 'processed one',
+            ocrConfidence: 0.9,
+          ),
+          Page(
+            id: 'e2e-page-2',
+            documentId: document.id,
+            pageNumber: 2,
+            rawText: 'raw two',
+            processedText: 'processed two',
+            ocrConfidence: 0.88,
+          ),
+        ];
+        await ctx.pageRepository.insertAll(pages);
+
+        // Summary for the document.
+        final summary = Summary(
+          documentId: document.id,
+          text: 'A concise summary of the document.',
+          modelVersion: 'qwen2.5-0.5b',
+          createdAt: now,
+        );
+        await ctx.summaryRepository.upsert(summary);
+
+        // Keywords and document-keyword relations.
+        final topicKeyword =
+            await ctx.keywordRepository.getOrCreate('taxes', 'topic');
+        final yearKeyword =
+            await ctx.keywordRepository.getOrCreate('2024', 'date');
+
+        final relations = <DocumentKeywordRelation>[
+          DocumentKeywordRelation(
+            id: 'e2e-dk-1',
+            documentId: document.id,
+            keywordId: topicKeyword.id,
+            weight: 0.8,
+            confidence: 0.9,
+            source: 'llm_initial',
+          ),
+          DocumentKeywordRelation(
+            id: 'e2e-dk-2',
+            documentId: document.id,
+            keywordId: yearKeyword.id,
+            weight: 0.6,
+            confidence: 0.85,
+            source: 'llm_initial',
+          ),
+        ];
+        await ctx.documentKeywordRepository.upsertForDocument(
+          document.id,
+          relations,
+        );
+
+        // Embedding for the document.
+        final embedding = Embedding(
+          documentId: document.id,
+          vector: <double>[0.1, -0.2, 0.3],
+          modelVersion: 'embed-model-v1',
+          createdAt: now,
+        );
+        await ctx.embeddingRepository.upsert(embedding);
+
+        // Act: read data back through repositories.
+        final foundDoc = await ctx.documentRepository.findById(document.id);
+        final foundPages =
+            await ctx.pageRepository.findByDocumentId(document.id);
+        final foundSummary =
+            await ctx.summaryRepository.findByDocumentId(document.id);
+        final foundKeywords =
+            await ctx.documentKeywordRepository.listForDocument(document.id);
+        final foundEmbedding =
+            await ctx.embeddingRepository.findByDocumentId(document.id);
+
+        // Assert: document + place link.
+        expect(foundDoc, isNotNull);
+        expect(foundDoc!.id, document.id);
+        expect(foundDoc.title, document.title);
+        expect(foundDoc.placeId, place.id);
+        expect(foundDoc.status, DocumentStatus.completed);
+        expect(foundDoc.confidenceScore, closeTo(0.95, 1e-9));
+
+        // Assert: pages are round-tripped in order.
+        expect(foundPages, hasLength(2));
+        expect(foundPages.first.pageNumber, 1);
+        expect(foundPages.last.pageNumber, 2);
+        expect(foundPages.first.processedText, 'processed one');
+        expect(foundPages.last.processedText, 'processed two');
+
+        // Assert: summary is present and matches.
+        expect(foundSummary, isNotNull);
+        expect(foundSummary!.documentId, document.id);
+        expect(foundSummary.text, summary.text);
+        expect(foundSummary.modelVersion, summary.modelVersion);
+
+        // Assert: keywords returned for the document.
+        final keywordValues = foundKeywords.map((k) => k.value).toSet();
+        expect(keywordValues, {'taxes', '2024'});
+
+        // Assert: embedding round-trips.
+        expect(foundEmbedding, isNotNull);
+        expect(foundEmbedding!.documentId, document.id);
+        expect(foundEmbedding.vector, <double>[0.1, -0.2, 0.3]);
+        expect(foundEmbedding.modelVersion, 'embed-model-v1');
+      },
+    );
+  });
+}
+


### PR DESCRIPTION
## What changed

- **Added a shared storage integration harness** that creates a fully migrated in-memory SQLite database and wires up all storage repositories (`Document`, `Place`, `Page`, `Summary`, `Keyword`, `DocumentKeywordRelation`, `Embedding`) for end-to-end tests.
- **Implemented a happy-path storage integration test** that exercises the full flow:
  - Create a `Place` and `Document`.
  - Insert `Page` rows.
  - Upsert a `Summary`.
  - Create `Keyword`s and `DocumentKeywordRelation`s.
  - Upsert an `Embedding`.
  - Read everything back via repositories and verify relationships and data integrity.
- **Added integration coverage for document filtering** using the real schema:
  - Filter by `status`.
  - Filter by `placeId`.
  - Filter by a `createdAt` date range.
  - Combined filters (`status` + `placeId` + range) to verify the query composition.
- **Added a constraint failure integration test** that verifies foreign-key enforcement by asserting that `SummaryRepository.upsert` fails with `StorageConstraintError` when called for a non-existent `documentId`.

## Why it changed

- Issue 16 requires storage-layer **integration tests** that validate the full stack (migrations + repositories + constraints), beyond isolated unit tests.
- The new harness and tests provide realistic end-to-end coverage for typical flows (document ingest, enrichment, and retrieval) and ensure that filtering logic and foreign-key constraints behave as expected in a migrated schema.
- This lays the groundwork for future features (e.g. richer search, FTS-based queries) by giving a reliable, reusable integration harness for the storage layer.

## How to test

1. Checkout this branch and install dependencies if needed.
2. Run the Dart/Flutter test suite, focusing on SQLite storage tests:
   - `flutter test test/infrastructure/sqlite/sqlite_storage_integration_harness.dart`
   - `flutter test test/infrastructure/sqlite/sqlite_storage_integration_test.dart`
3. Optionally run the full storage suite to confirm nothing regressed:
   - `flutter test test/infrastructure/sqlite`

All tests should pass, and the new integration tests should execute against a fully migrated in-memory SQLite database.

---

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if/where we document storage testing strategy)
- [x] Linter/Formatter passes
- [x] No debug logs or stray TODOs left in code