### PR TITLE
Feat/add documentfilestorage abstraction and local implementation

### DIFF
--- a/lib/infrastructure/file_storage/local_document_file_storage.dart
+++ b/lib/infrastructure/file_storage/local_document_file_storage.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import '../../src/domain/document_file_storage.dart';
+import '../../src/domain/file_storage_error.dart';
+
+/// A local file system implementation of [DocumentFileStorage].
+class LocalDocumentFileStorage implements DocumentFileStorage {
+  final String _storageRoot;
+
+  /// Creates a new [LocalDocumentFileStorage] with the given [_storageRoot].
+  ///
+  /// Throws an [InvalidStorageRootError] if the root directory cannot be created
+  /// or accessed.
+  LocalDocumentFileStorage(this._storageRoot) {
+    _ensureRootExists();
+  }
+
+  void _ensureRootExists() {
+    try {
+      final dir = Directory(_storageRoot);
+      if (!dir.existsSync()) {
+        dir.createSync(recursive: true);
+      }
+    } catch (e) {
+      throw InvalidStorageRootError('Failed to create storage root: $_storageRoot', e);
+    }
+  }
+
+  @override
+  String pathForDocument(String documentId) {
+    return p.join(_storageRoot, '$documentId.pdf');
+  }
+
+  @override
+  Future<void> storeForDocument(String documentId, String sourceFilePath) async {
+    final sourceFile = File(sourceFilePath);
+    if (!await sourceFile.exists()) {
+      throw FileNotFoundStorageError(sourceFilePath);
+    }
+
+    final destinationPath = pathForDocument(documentId);
+    try {
+      await sourceFile.copy(destinationPath);
+    } catch (e) {
+      throw FileIoStorageError('Failed to copy file to $destinationPath', e);
+    }
+  }
+
+  @override
+  Future<void> removeForDocument(String documentId) async {
+    final file = File(pathForDocument(documentId));
+    if (await file.exists()) {
+      try {
+        await file.delete();
+      } catch (e) {
+        throw FileIoStorageError('Failed to delete file at ${file.path}', e);
+      }
+    }
+  }
+}

--- a/lib/src/domain/document_file_storage.dart
+++ b/lib/src/domain/document_file_storage.dart
@@ -1,4 +1,4 @@
-abstract interface class DocumentFileStorage {
+abstract class DocumentFileStorage {
   /// Stores a document file from the given [sourceFilePath] for the specified [documentId].
   Future<void> storeForDocument(String documentId, String sourceFilePath);
 

--- a/lib/src/domain/document_file_storage.dart
+++ b/lib/src/domain/document_file_storage.dart
@@ -1,0 +1,10 @@
+abstract interface class DocumentFileStorage {
+  /// Stores a document file from the given [sourceFilePath] for the specified [documentId].
+  Future<void> storeForDocument(String documentId, String sourceFilePath);
+
+  /// Returns the deterministic path where the document with [documentId] is stored.
+  String pathForDocument(String documentId);
+
+  /// Removes the stored file for the specified [documentId].
+  Future<void> removeForDocument(String documentId);
+}

--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -1,10 +1,12 @@
 export 'date_time_range.dart';
 export 'document.dart';
+export 'document_file_storage.dart';
 export 'document_keyword_relation.dart';
 export 'document_keyword_repository.dart';
 export 'document_repository.dart';
 export 'embedding.dart';
 export 'embedding_repository.dart';
+export 'file_storage_error.dart';
 export 'keyword.dart';
 export 'keyword_repository.dart';
 export 'page.dart';

--- a/lib/src/domain/file_storage_error.dart
+++ b/lib/src/domain/file_storage_error.dart
@@ -1,0 +1,28 @@
+/// Base class for all file storage errors.
+sealed class FileStorageError implements Exception {
+  final String message;
+  final Object? cause;
+
+  const FileStorageError(this.message, [this.cause]);
+
+  @override
+  String toString() => 'FileStorageError: $message${cause != null ? ' (Cause: $cause)' : ''}';
+}
+
+/// Thrown when a file cannot be found at the specified path.
+class FileNotFoundStorageError extends FileStorageError {
+  final String path;
+
+  const FileNotFoundStorageError(this.path, [super.cause])
+      : super('File not found at path: $path');
+}
+
+/// Thrown when there is an error reading or writing a file.
+class FileIoStorageError extends FileStorageError {
+  const FileIoStorageError(super.message, [super.cause]);
+}
+
+/// Thrown when the storage root directory is invalid or inaccessible.
+class InvalidStorageRootError extends FileStorageError {
+  const InvalidStorageRootError(super.message, [super.cause]);
+}

--- a/lib/src/domain/file_storage_error.dart
+++ b/lib/src/domain/file_storage_error.dart
@@ -1,5 +1,5 @@
 /// Base class for all file storage errors.
-sealed class FileStorageError implements Exception {
+abstract class FileStorageError implements Exception {
   final String message;
   final Object? cause;
 
@@ -13,16 +13,16 @@ sealed class FileStorageError implements Exception {
 class FileNotFoundStorageError extends FileStorageError {
   final String path;
 
-  const FileNotFoundStorageError(this.path, [super.cause])
-      : super('File not found at path: $path');
+  const FileNotFoundStorageError(this.path, [Object? cause])
+      : super('File not found at path: $path', cause);
 }
 
 /// Thrown when there is an error reading or writing a file.
 class FileIoStorageError extends FileStorageError {
-  const FileIoStorageError(super.message, [super.cause]);
+  const FileIoStorageError(String message, [Object? cause]) : super(message, cause);
 }
 
 /// Thrown when the storage root directory is invalid or inaccessible.
 class InvalidStorageRootError extends FileStorageError {
-  const InvalidStorageRootError(super.message, [super.cause]);
+  const InvalidStorageRootError(String message, [Object? cause]) : super(message, cause);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -211,7 +211,7 @@ packages:
     source: hosted
     version: "0.17.4"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  path: ^1.9.1
   sqlite3: ^3.1.6
   
 

--- a/test/infrastructure/file_storage/local_document_file_storage_test.dart
+++ b/test/infrastructure/file_storage/local_document_file_storage_test.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:personal_archive/infrastructure/file_storage/local_document_file_storage.dart';
+import 'package:personal_archive/src/domain/file_storage_error.dart';
+
+void main() {
+  late Directory tempDir;
+  late LocalDocumentFileStorage storage;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('local_document_file_storage_test_');
+    storage = LocalDocumentFileStorage(tempDir.path);
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('LocalDocumentFileStorage', () {
+    test('creates storage root if it does not exist', () {
+      final newRoot = p.join(tempDir.path, 'new_root');
+      expect(Directory(newRoot).existsSync(), isFalse);
+
+      LocalDocumentFileStorage(newRoot);
+
+      expect(Directory(newRoot).existsSync(), isTrue);
+    });
+
+    test('pathForDocument returns deterministic path', () {
+      final documentId = 'doc-123';
+      final expectedPath = p.join(tempDir.path, '$documentId.pdf');
+
+      expect(storage.pathForDocument(documentId), expectedPath);
+    });
+
+    test('storeForDocument copies file successfully', () async {
+      final documentId = 'doc-456';
+      final sourceFile = File(p.join(tempDir.path, 'source.pdf'));
+      await sourceFile.writeAsString('dummy pdf content');
+
+      await storage.storeForDocument(documentId, sourceFile.path);
+
+      final destinationPath = storage.pathForDocument(documentId);
+      final destinationFile = File(destinationPath);
+
+      expect(await destinationFile.exists(), isTrue);
+      expect(await destinationFile.readAsString(), 'dummy pdf content');
+    });
+
+    test('storeForDocument throws FileNotFoundStorageError if source does not exist', () async {
+      final documentId = 'doc-789';
+      final nonExistentPath = p.join(tempDir.path, 'non_existent.pdf');
+
+      expect(
+        () => storage.storeForDocument(documentId, nonExistentPath),
+        throwsA(isA<FileNotFoundStorageError>()),
+      );
+    });
+
+    test('removeForDocument deletes file successfully', () async {
+      final documentId = 'doc-abc';
+      final destinationPath = storage.pathForDocument(documentId);
+      final destinationFile = File(destinationPath);
+      await destinationFile.writeAsString('dummy content to delete');
+
+      expect(await destinationFile.exists(), isTrue);
+
+      await storage.removeForDocument(documentId);
+
+      expect(await destinationFile.exists(), isFalse);
+    });
+
+    test('removeForDocument does nothing if file does not exist', () async {
+      final documentId = 'doc-def';
+      final destinationPath = storage.pathForDocument(documentId);
+      final destinationFile = File(destinationPath);
+
+      expect(await destinationFile.exists(), isFalse);
+
+      // Should not throw
+      await storage.removeForDocument(documentId);
+    });
+  });
+}


### PR DESCRIPTION
## Description
This PR introduces the `DocumentFileStorage` abstraction and its local file system implementation, `LocalDocumentFileStorage`. This provides a deterministic, local-first strategy for storing imported PDFs under the app's control, which is a prerequisite for the PDF input pipeline.

## Changes
- **Domain**: Added `DocumentFileStorage` interface and a `FileStorageError` hierarchy for typed storage exceptions.
- **Infrastructure**: Implemented `LocalDocumentFileStorage` that stores PDFs deterministically (`<root>/<documentId>.pdf`) under a configurable root directory.
- **Tests**: Added comprehensive unit tests for successful storage/removal and error handling.
- **Fix**: Ensured compatibility with Dart 2.19 by removing Dart 3 specific modifiers (`sealed`, `interface`).

## Related Issue
Resolves Phase 2 – 1. Add `DocumentFileStorage` Abstraction and Local Implementation

## Definition of Done
- [x] Interface defined in application/domain layer.
- [x] Local implementation uses configurable storage root.
- [x] Unit tests cover success and error cases.
- [x] CI/Tests pass locally.