### PR TITLE
Feat/implement pdf import validation rules

### DIFF
--- a/lib/src/application/application.dart
+++ b/lib/src/application/application.dart
@@ -1,1 +1,2 @@
+export 'import_validator.dart';
 export 'pdf_metadata_reader.dart';

--- a/lib/src/application/import_validator.dart
+++ b/lib/src/application/import_validator.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import '../domain/domain.dart';
+
+/// Validates PDF files before importing them into the system.
+class ImportValidator {
+  const ImportValidator({
+    this.config = const ImportConfiguration(),
+  });
+
+  final ImportConfiguration config;
+
+  /// Validates the file at the given [path].
+  ///
+  /// Throws an [ImportValidationError] if validation fails.
+  Future<void> validateFile(String path) async {
+    final file = File(path);
+
+    // 1. Check if file exists and is a regular file
+    if (!await file.exists()) {
+      throw FileDoesNotExistError(path);
+    }
+
+    // 2. Check if file is readable (by trying to open it for reading)
+    try {
+      final randomAccessFile = await file.open(mode: FileMode.read);
+      await randomAccessFile.close();
+    } catch (e) {
+      throw FileNotReadableError(path);
+    }
+
+    // 3. Check file extension
+    if (!path.toLowerCase().endsWith('.pdf')) {
+      throw InvalidPdfFormatError(path);
+    }
+
+    // 4. Check file size
+    final sizeBytes = await file.length();
+    if (sizeBytes > config.maxFileSizeBytes) {
+      throw FileTooLargeError(path, sizeBytes, config.maxFileSizeBytes);
+    }
+  }
+}

--- a/lib/src/application/import_validator.dart
+++ b/lib/src/application/import_validator.dart
@@ -1,19 +1,23 @@
 import 'dart:io';
 
 import '../domain/domain.dart';
+import 'pdf_metadata_reader.dart';
 
 /// Validates PDF files before importing them into the system.
 class ImportValidator {
   const ImportValidator({
+    required this.pdfMetadataReader,
     this.config = const ImportConfiguration(),
   });
 
+  final PdfMetadataReader pdfMetadataReader;
   final ImportConfiguration config;
 
   /// Validates the file at the given [path].
   ///
   /// Throws an [ImportValidationError] if validation fails.
-  Future<void> validateFile(String path) async {
+  /// Returns the [PdfMetadata] if validation succeeds, to avoid reading the PDF twice.
+  Future<PdfMetadata> validateFile(String path) async {
     final file = File(path);
 
     // 1. Check if file exists and is a regular file
@@ -38,6 +42,17 @@ class ImportValidator {
     final sizeBytes = await file.length();
     if (sizeBytes > config.maxFileSizeBytes) {
       throw FileTooLargeError(path, sizeBytes, config.maxFileSizeBytes);
+    }
+
+    // 5. Check PDF format and page count
+    try {
+      final metadata = await pdfMetadataReader.read(path);
+      if (metadata.pageCount > config.maxPageCount) {
+        throw TooManyPagesError(path, metadata.pageCount, config.maxPageCount);
+      }
+      return metadata;
+    } on PdfReadError catch (_) {
+      throw InvalidPdfFormatError(path);
     }
   }
 }

--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -7,6 +7,7 @@ export 'document_repository.dart';
 export 'embedding.dart';
 export 'embedding_repository.dart';
 export 'file_storage_error.dart';
+export 'import_validation_error.dart';
 export 'keyword.dart';
 export 'keyword_repository.dart';
 export 'page.dart';

--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -7,6 +7,7 @@ export 'document_repository.dart';
 export 'embedding.dart';
 export 'embedding_repository.dart';
 export 'file_storage_error.dart';
+export 'import_configuration.dart';
 export 'import_validation_error.dart';
 export 'keyword.dart';
 export 'keyword_repository.dart';

--- a/lib/src/domain/import_configuration.dart
+++ b/lib/src/domain/import_configuration.dart
@@ -1,0 +1,13 @@
+/// Configuration for the PDF import pipeline.
+class ImportConfiguration {
+  const ImportConfiguration({
+    this.maxFileSizeBytes = 50 * 1024 * 1024, // 50 MB default
+    this.maxPageCount = 1000, // 1000 pages default
+  });
+
+  /// The maximum allowed file size in bytes.
+  final int maxFileSizeBytes;
+
+  /// The maximum allowed number of pages in a PDF.
+  final int maxPageCount;
+}

--- a/lib/src/domain/import_validation_error.dart
+++ b/lib/src/domain/import_validation_error.dart
@@ -1,0 +1,80 @@
+/// Typed error for PDF import validation failures.
+abstract class ImportValidationError implements Exception {
+  const ImportValidationError();
+
+  /// A machine-readable code for the error.
+  String get code;
+
+  /// A human-readable message describing the error.
+  String get message;
+
+  @override
+  String toString() => 'ImportValidationError($code): $message';
+}
+
+/// Error thrown when the file does not exist or is not a regular file.
+class FileDoesNotExistError extends ImportValidationError {
+  const FileDoesNotExistError(this.path);
+  final String path;
+
+  @override
+  String get code => 'file_not_found';
+
+  @override
+  String get message =>
+      'The file at $path does not exist or is not a regular file.';
+}
+
+/// Error thrown when the file cannot be read.
+class FileNotReadableError extends ImportValidationError {
+  const FileNotReadableError(this.path);
+  final String path;
+
+  @override
+  String get code => 'file_not_readable';
+
+  @override
+  String get message => 'The file at $path cannot be read.';
+}
+
+/// Error thrown when the file is not a valid PDF.
+class InvalidPdfFormatError extends ImportValidationError {
+  const InvalidPdfFormatError(this.path);
+  final String path;
+
+  @override
+  String get code => 'invalid_pdf_format';
+
+  @override
+  String get message => 'The file at $path is not a valid PDF.';
+}
+
+/// Error thrown when the file exceeds the maximum allowed size.
+class FileTooLargeError extends ImportValidationError {
+  const FileTooLargeError(this.path, this.sizeBytes, this.maxSizeBytes);
+  final String path;
+  final int sizeBytes;
+  final int maxSizeBytes;
+
+  @override
+  String get code => 'file_too_large';
+
+  @override
+  String get message =>
+      'The file at $path is too large ($sizeBytes bytes). Maximum allowed size is $maxSizeBytes bytes.';
+}
+
+/// Error thrown when the PDF has too many pages.
+class TooManyPagesError extends ImportValidationError {
+  const TooManyPagesError(this.path, this.pageCount, this.maxPageCount);
+  final String path;
+  final int pageCount;
+  final int maxPageCount;
+
+  @override
+  String get code => 'too_many_pages';
+
+  @override
+  String get message =>
+      'The PDF at $path has too many pages ($pageCount). Maximum allowed is $maxPageCount pages.';
+}

--- a/lib/src/service_locator.dart
+++ b/lib/src/service_locator.dart
@@ -1,5 +1,5 @@
 import 'package:personal_archive/infrastructure/pdf/pdf_metadata_reader_impl.dart';
-import 'package:personal_archive/src/application/pdf_metadata_reader.dart';
+import 'package:personal_archive/src/application/application.dart';
 
 /// Simple service locator for dependency injection.
 ///
@@ -11,6 +11,7 @@ class ServiceLocator {
   static final ServiceLocator instance = ServiceLocator._();
 
   PdfMetadataReader? _pdfMetadataReader;
+  ImportValidator? _importValidator;
 
   /// Returns the registered [PdfMetadataReader] implementation.
   PdfMetadataReader get pdfMetadataReader {
@@ -22,8 +23,21 @@ class ServiceLocator {
     _pdfMetadataReader = reader;
   }
 
+  /// Returns the registered [ImportValidator] implementation.
+  ImportValidator get importValidator {
+    return _importValidator ??= ImportValidator(
+      pdfMetadataReader: pdfMetadataReader,
+    );
+  }
+
+  /// Overrides the [ImportValidator] instance (useful for testing).
+  set importValidator(ImportValidator validator) {
+    _importValidator = validator;
+  }
+
   /// Resets all registrations. Intended for test teardown only.
   void reset() {
     _pdfMetadataReader = null;
+    _importValidator = null;
   }
 }

--- a/test/application/import_validator_test.dart
+++ b/test/application/import_validator_test.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/src/application/application.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+
+class FakePdfMetadataReader implements PdfMetadataReader {
+  FakePdfMetadataReader({
+    this.metadataToReturn,
+    this.errorToThrow,
+  });
+
+  final PdfMetadata? metadataToReturn;
+  final Object? errorToThrow;
+
+  @override
+  Future<PdfMetadata> read(String path) async {
+    if (errorToThrow != null) {
+      throw errorToThrow!;
+    }
+    return metadataToReturn ?? const PdfMetadata(pageCount: 1);
+  }
+}
+
+void main() {
+  group('ImportValidator', () {
+    late Directory tempDir;
+    late ImportValidator validator;
+    late FakePdfMetadataReader fakeReader;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('import_validator_test');
+      fakeReader = FakePdfMetadataReader();
+      validator = ImportValidator(
+        pdfMetadataReader: fakeReader,
+        config: const ImportConfiguration(
+          maxFileSizeBytes: 1024, // 1 KB for testing
+          maxPageCount: 10, // 10 pages for testing
+        ),
+      );
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('throws FileDoesNotExistError when file does not exist', () async {
+      final file = File('${tempDir.path}/missing.pdf');
+
+      expect(
+        () => validator.validateFile(file.path),
+        throwsA(isA<FileDoesNotExistError>()),
+      );
+    });
+
+    test('throws InvalidPdfFormatError when file extension is not .pdf',
+        () async {
+      final file = File('${tempDir.path}/test.txt')..createSync();
+
+      expect(
+        () => validator.validateFile(file.path),
+        throwsA(isA<InvalidPdfFormatError>()),
+      );
+    });
+
+    test('throws FileTooLargeError when file exceeds max size', () async {
+      final file = File('${tempDir.path}/large.pdf')..createSync();
+      // Write 2 KB of data
+      file.writeAsBytesSync(List.filled(2048, 0));
+
+      expect(
+        () => validator.validateFile(file.path),
+        throwsA(isA<FileTooLargeError>()),
+      );
+    });
+
+    test(
+        'throws InvalidPdfFormatError when PdfMetadataReader throws PdfReadError',
+        () async {
+      final file = File('${tempDir.path}/invalid.pdf')..createSync();
+      fakeReader = FakePdfMetadataReader(
+        errorToThrow: const PdfReadError('Invalid PDF'),
+      );
+      validator = ImportValidator(
+        pdfMetadataReader: fakeReader,
+        config: const ImportConfiguration(),
+      );
+
+      expect(
+        () => validator.validateFile(file.path),
+        throwsA(isA<InvalidPdfFormatError>()),
+      );
+    });
+
+    test('throws TooManyPagesError when PDF has too many pages', () async {
+      final file = File('${tempDir.path}/long.pdf')..createSync();
+      fakeReader = FakePdfMetadataReader(
+        metadataToReturn: const PdfMetadata(pageCount: 20),
+      );
+      validator = ImportValidator(
+        pdfMetadataReader: fakeReader,
+        config: const ImportConfiguration(maxPageCount: 10),
+      );
+
+      expect(
+        () => validator.validateFile(file.path),
+        throwsA(isA<TooManyPagesError>()),
+      );
+    });
+
+    test('returns PdfMetadata when validation succeeds', () async {
+      final file = File('${tempDir.path}/valid.pdf')..createSync();
+      final expectedMetadata = const PdfMetadata(pageCount: 5);
+      fakeReader = FakePdfMetadataReader(
+        metadataToReturn: expectedMetadata,
+      );
+      validator = ImportValidator(
+        pdfMetadataReader: fakeReader,
+        config: const ImportConfiguration(maxPageCount: 10),
+      );
+
+      final metadata = await validator.validateFile(file.path);
+
+      expect(metadata, equals(expectedMetadata));
+    });
+  });
+}


### PR DESCRIPTION
## What changed
- Added `ImportValidationError` types for specific failure cases (missing file, unreadable, invalid format, size/page limits).
- Created `ImportConfiguration` to centralize validation limits (default 50MB, 1000 pages).
- Implemented `ImportValidator` to enforce basic file checks and PDF page count limits using `PdfMetadataReader`.
- Integrated the validator into the `ServiceLocator` for use in the import pipeline.
- Added comprehensive unit tests for all validation rules.

## Why it changed
To ensure the system only processes well-formed, manageable PDF documents. This prevents the pipeline from attempting to import non-PDFs, excessively large files, or documents with too many pages, which could lead to poor UX and failures in later stages (OCR, LLM).

## How to test
1. Run the unit tests: `flutter test test/application/import_validator_test.dart`
2. Verify all tests pass, covering missing files, invalid extensions, size limits, invalid PDF formats, and page count limits.

## Checklist
- [x] Tests added/updated
- [x] Documentation updated (including ADRs if applicable)
- [x] Linter/Formatter passes
- [x] No debug logs or "TODOs" left in code