### PR TITLE
Feat/implement documentpipelineimportfrompath

### DIFF
--- a/lib/src/application/document_pipeline.dart
+++ b/lib/src/application/document_pipeline.dart
@@ -1,0 +1,38 @@
+import '../domain/document.dart';
+
+/// Result of a successful document import.
+class ImportResult {
+  final Document document;
+  final int pageCount;
+
+  const ImportResult({
+    required this.document,
+    required this.pageCount,
+  });
+
+  @override
+  String toString() => 'ImportResult(document: ${document.id}, pageCount: $pageCount)';
+  
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImportResult &&
+          runtimeType == other.runtimeType &&
+          document == other.document &&
+          pageCount == other.pageCount;
+
+  @override
+  int get hashCode => document.hashCode ^ pageCount.hashCode;
+}
+
+/// Orchestrates the import of a document from a raw file path into the system.
+///
+/// This pipeline handles validation, file storage, metadata extraction, and
+/// the initial creation of Document and Page records.
+abstract class DocumentPipeline {
+  /// Imports a document from the given [sourcePath].
+  ///
+  /// Returns an [ImportResult] containing the created document and page count.
+  /// Throws specific exceptions for validation, storage, or processing errors.
+  Future<ImportResult> importFromPath(String sourcePath);
+}

--- a/lib/src/application/document_pipeline_impl.dart
+++ b/lib/src/application/document_pipeline_impl.dart
@@ -1,0 +1,40 @@
+import '../domain/document.dart';
+import '../domain/document_file_storage.dart';
+import '../domain/document_repository.dart';
+import '../domain/page_repository.dart';
+import '../domain/pdf_metadata.dart';
+import 'document_pipeline.dart';
+import 'import_validator.dart';
+import 'pdf_metadata_reader.dart';
+
+/// Concrete implementation of the [DocumentPipeline].
+class DocumentPipelineImpl implements DocumentPipeline {
+  const DocumentPipelineImpl({
+    required this.validator,
+    required this.fileStorage,
+    required this.metadataReader,
+    required this.documentRepository,
+    required this.pageRepository,
+  });
+
+  final ImportValidator validator;
+  final DocumentFileStorage fileStorage;
+  final PdfMetadataReader metadataReader;
+  final DocumentRepository documentRepository;
+  final PageRepository pageRepository;
+
+  @override
+  Future<ImportResult> importFromPath(String sourcePath) async {
+    // 1. Validation
+    
+    // 2. File Storage
+    
+    // 3. Document Creation
+    
+    // 4. Page Extraction (Metadata)
+    
+    // 5. Page Creation
+    
+    throw UnimplementedError();
+  }
+}

--- a/lib/src/application/document_pipeline_impl.dart
+++ b/lib/src/application/document_pipeline_impl.dart
@@ -1,3 +1,4 @@
+import 'package:uuid/uuid.dart';
 import '../domain/document.dart';
 import '../domain/document_file_storage.dart';
 import '../domain/document_repository.dart';
@@ -29,7 +30,10 @@ class DocumentPipelineImpl implements DocumentPipeline {
     final metadata = await validator.validateFile(sourcePath);
 
     // 2. File Storage
-    
+    final documentId = const Uuid().v4();
+    await fileStorage.storeForDocument(documentId, sourcePath);
+    final storagePath = fileStorage.pathForDocument(documentId);
+
     // 3. Document Creation
     
     // 4. Page Extraction (Metadata)

--- a/lib/src/application/document_pipeline_impl.dart
+++ b/lib/src/application/document_pipeline_impl.dart
@@ -1,4 +1,5 @@
 import 'package:uuid/uuid.dart';
+import 'package:path/path.dart' as p;
 import '../domain/document.dart';
 import '../domain/document_file_storage.dart';
 import '../domain/document_repository.dart';
@@ -35,7 +36,21 @@ class DocumentPipelineImpl implements DocumentPipeline {
     final storagePath = fileStorage.pathForDocument(documentId);
 
     // 3. Document Creation
+    final title = p.basenameWithoutExtension(sourcePath);
+    final now = DateTime.now().toUtc();
     
+    final document = Document(
+      id: documentId,
+      title: title,
+      filePath: storagePath,
+      status: DocumentStatus.imported,
+      createdAt: now,
+      updatedAt: now,
+      // confidenceScore and placeId are null initially
+    );
+    
+    await documentRepository.create(document);
+
     // 4. Page Extraction (Metadata)
     
     // 5. Page Creation

--- a/lib/src/application/document_pipeline_impl.dart
+++ b/lib/src/application/document_pipeline_impl.dart
@@ -1,6 +1,7 @@
 import 'package:uuid/uuid.dart';
 import 'package:path/path.dart' as p;
 import '../domain/document.dart';
+import '../domain/page.dart';
 import '../domain/document_file_storage.dart';
 import '../domain/document_repository.dart';
 import '../domain/page_repository.dart';
@@ -52,9 +53,23 @@ class DocumentPipelineImpl implements DocumentPipeline {
     await documentRepository.create(document);
 
     // 4. Page Extraction (Metadata)
+    // We already have the metadata from the validation step.
+    final pageCount = metadata.pageCount;
     
     // 5. Page Creation
-    
-    throw UnimplementedError();
+    final pages = List.generate(pageCount, (index) {
+      final pageNumber = index + 1;
+      return Page(
+        documentId: documentId,
+        pageNumber: pageNumber,
+      );
+    });
+
+    await pageRepository.insertAll(pages);
+
+    return ImportResult(
+      document: document,
+      pageCount: pageCount,
+    );
   }
 }

--- a/lib/src/application/document_pipeline_impl.dart
+++ b/lib/src/application/document_pipeline_impl.dart
@@ -57,9 +57,10 @@ class DocumentPipelineImpl implements DocumentPipeline {
     final pageCount = metadata.pageCount;
     
     // 5. Page Creation
-    final pages = List.generate(pageCount, (index) {
+    final pages = List<Page>.generate(pageCount, (index) {
       final pageNumber = index + 1;
       return Page(
+        id: const Uuid().v4(),
         documentId: documentId,
         pageNumber: pageNumber,
       );

--- a/lib/src/application/document_pipeline_impl.dart
+++ b/lib/src/application/document_pipeline_impl.dart
@@ -25,8 +25,9 @@ class DocumentPipelineImpl implements DocumentPipeline {
 
   @override
   Future<ImportResult> importFromPath(String sourcePath) async {
-    // 1. Validation
-    
+    // 1. Validation. We get the metadata here to avoid reading it twice.
+    final metadata = await validator.validateFile(sourcePath);
+
     // 2. File Storage
     
     // 3. Document Creation

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -223,6 +223,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -381,7 +389,7 @@ packages:
     source: hosted
     version: "1.1.0"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   path: ^1.9.1
   pdfx: ^2.9.2
   sqlite3: ^3.1.6
+  uuid: ^4.5.2
 
 
 dev_dependencies:
@@ -24,6 +25,7 @@ dev_dependencies:
     sdk: flutter
 
   flutter_lints: ^2.0.0
+  mocktail: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/test/application/document_pipeline_test.dart
+++ b/test/application/document_pipeline_test.dart
@@ -1,0 +1,97 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:personal_archive/src/application/document_pipeline_impl.dart';
+import 'package:personal_archive/src/application/import_validator.dart';
+import 'package:personal_archive/src/application/pdf_metadata_reader.dart'; // Added missing import
+import 'package:personal_archive/src/domain/document.dart';
+import 'package:personal_archive/src/domain/document_file_storage.dart';
+import 'package:personal_archive/src/domain/document_repository.dart';
+import 'package:personal_archive/src/domain/page_repository.dart';
+import 'package:personal_archive/src/domain/pdf_metadata.dart';
+import 'package:flutter_test/flutter_test.dart'; // Changed from package:test
+
+class MockImportValidator extends Mock implements ImportValidator {}
+class MockDocumentFileStorage extends Mock implements DocumentFileStorage {}
+class MockPdfMetadataReader extends Mock implements PdfMetadataReader {} // This is just a placeholder since we use Validator for metadata
+class MockDocumentRepository extends Mock implements DocumentRepository {}
+class MockPageRepository extends Mock implements PageRepository {}
+
+void main() {
+  group('DocumentPipelineImpl', () {
+    late DocumentPipelineImpl pipeline;
+    late MockImportValidator mockValidator;
+    late MockDocumentFileStorage mockFileStorage;
+    late MockPdfMetadataReader mockMetadataReader;
+    late MockDocumentRepository mockDocumentRepository;
+    late MockPageRepository mockPageRepository;
+
+    setUp(() {
+      mockValidator = MockImportValidator();
+      mockFileStorage = MockDocumentFileStorage();
+      mockMetadataReader = MockPdfMetadataReader();
+      mockDocumentRepository = MockDocumentRepository();
+      mockPageRepository = MockPageRepository();
+
+      pipeline = DocumentPipelineImpl(
+        validator: mockValidator,
+        fileStorage: mockFileStorage,
+        metadataReader: mockMetadataReader,
+        documentRepository: mockDocumentRepository,
+        pageRepository: mockPageRepository,
+      );
+      
+      // Register fallback values for arguments used in `any()` or `captureAny()`
+      registerFallbackValue(
+        Document(
+          id: 'test-id',
+          title: 'test',
+          filePath: 'test',
+          status: DocumentStatus.imported,
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      );
+    });
+
+    test('importFromPath successfully creates document and pages', () async {
+      // Arrange
+      const sourcePath = '/tmp/test_document.pdf';
+      const storagePath = '/app/storage/uuid.pdf';
+      const pageCount = 3;
+      
+      when(() => mockValidator.validateFile(sourcePath))
+          .thenAnswer((_) async => const PdfMetadata(pageCount: pageCount));
+          
+      when(() => mockFileStorage.storeForDocument(any(), sourcePath))
+          .thenAnswer((_) async {});
+          
+      when(() => mockFileStorage.pathForDocument(any()))
+          .thenReturn(storagePath);
+          
+      when(() => mockDocumentRepository.create(any()))
+          .thenAnswer((invocation) async => invocation.positionalArguments.first as Document);
+          
+      when(() => mockPageRepository.insertAll(any()))
+          .thenAnswer((_) async {});
+
+      // Act
+      final result = await pipeline.importFromPath(sourcePath);
+
+      // Assert
+      expect(result.pageCount, equals(pageCount));
+      expect(result.document.status, equals(DocumentStatus.imported));
+      expect(result.document.filePath, equals(storagePath));
+      expect(result.document.title, equals('test_document')); // basenameWithoutExtension
+
+      // Verify interactions
+      verify(() => mockValidator.validateFile(sourcePath)).called(1);
+      verify(() => mockFileStorage.storeForDocument(any(), sourcePath)).called(1);
+      verify(() => mockDocumentRepository.create(any())).called(1);
+      
+      // Verify pages creation
+      final capturedPages = verify(() => mockPageRepository.insertAll(captureAny())).captured.single as List;
+      expect(capturedPages.length, equals(pageCount));
+      expect(capturedPages[0].pageNumber, equals(1));
+      expect(capturedPages[2].pageNumber, equals(3));
+    });
+  });
+}


### PR DESCRIPTION
## Implement `DocumentPipeline.importFromPath`

**Issue:** #4
**Type:** `feat`
**Merges into:** `develop`

### Summary
Implements the core application logic for the PDF import pipeline. This `DocumentPipeline` orchestrates the flow from a raw file path to a fully persisted `Document` with associated `Page` records, enabling the first stage of the processing pipeline.

### Implementation Details
- **`DocumentPipeline` Interface:** Defines the contract for importing documents.
- **`DocumentPipelineImpl`:** Orchestrates the import steps:
  1. **Validation:** Checks file validity and eagerly extracts `PdfMetadata` (page count).
  2. **Storage:** Generates a UUID and safely stores the file using `DocumentFileStorage`.
  3. **Document Creation:** Persists the `Document` entity with `imported` status.
  4. **Page Generation:** Creates and persists `Page` entities (1..N) based on the page count.
- **Unit Tests:** Added comprehensive tests for the happy path using `mocktail`.

### Testing
- [x] **Unit Tests:** `test/application/document_pipeline_test.dart` passes (verifies orchestration, storage calls, and entity creation).
- [ ] **Integration:** (Planned for a future PR, but manual verification via a harness is possible).

### Dependencies
- Added `uuid` for stable ID generation.
- Added `mocktail` (dev) for robust testing.

### Checklist
- [x] Logic follows the phase 2 pipeline design.
- [x] All specific import steps (Validate → Store → Document → Pages) are implemented.
- [x] Tests pass and cover the orchestration flow.