### PR TITLE
Feat/integrate fts sync into import pipeline

### DIFF
--- a/lib/infrastructure/sqlite/sqlite_fts_sync_service.dart
+++ b/lib/infrastructure/sqlite/sqlite_fts_sync_service.dart
@@ -1,0 +1,16 @@
+import 'package:personal_archive/src/application/search_index_sync.dart';
+import 'package:personal_archive/infrastructure/sqlite/documents_fts_sync.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart'
+    show MigrationDb;
+
+/// SQLite implementation of [SearchIndexSync].
+class SqliteFtsSyncService implements SearchIndexSync {
+  const SqliteFtsSyncService(this._db);
+
+  final MigrationDb _db;
+
+  @override
+  Future<void> syncDocument(String documentId) async {
+    await syncFtsForDocument(_db, documentId);
+  }
+}

--- a/lib/src/application/application.dart
+++ b/lib/src/application/application.dart
@@ -1,2 +1,3 @@
 export 'import_validator.dart';
 export 'pdf_metadata_reader.dart';
+export 'search_index_sync.dart';

--- a/lib/src/application/search_index_sync.dart
+++ b/lib/src/application/search_index_sync.dart
@@ -1,0 +1,8 @@
+/// Contract for synchronizing search indices for a document.
+abstract class SearchIndexSync {
+  /// Synchronizes the search index for the document with the given [documentId].
+  ///
+  /// This operation is typically a best-effort side-effect and should not
+  /// prevent successful completion of other operations if it fails.
+  Future<void> syncDocument(String documentId);
+}

--- a/test/infrastructure/sqlite/document_pipeline_fts_test.dart
+++ b/test/infrastructure/sqlite/document_pipeline_fts_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_document_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_fts_sync_service.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_page_repository.dart';
+import 'package:personal_archive/src/application/document_pipeline_impl.dart';
+import 'package:personal_archive/src/application/import_validator.dart';
+import 'package:personal_archive/src/application/pdf_metadata_reader.dart';
+import 'package:personal_archive/src/domain/document_file_storage.dart';
+import 'package:personal_archive/src/domain/pdf_metadata.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+import 'sqlite_test_harness.dart';
+
+class MockImportValidator extends Mock implements ImportValidator {}
+class MockDocumentFileStorage extends Mock implements DocumentFileStorage {}
+class MockPdfMetadataReader extends Mock implements PdfMetadataReader {}
+
+void main() {
+  late sqlite.Database rawDb;
+  late Sqlite3MigrationDb db;
+  late SqliteDocumentRepository docRepo;
+  late SqlitePageRepository pageRepo;
+  late SqliteFtsSyncService ftsSync;
+  late DocumentPipelineImpl pipeline;
+  
+  late MockImportValidator mockValidator;
+  late MockDocumentFileStorage mockFileStorage;
+  late MockPdfMetadataReader mockMetadataReader;
+
+  setUp(() async {
+    // Ensure test binding is initialized for asset loading (migrations)
+    TestWidgetsFlutterBinding.ensureInitialized();
+
+    rawDb = sqlite.sqlite3.openInMemory();
+    db = Sqlite3MigrationDb(rawDb);
+
+    // Apply migrations
+    final migrations = await loadTestMigrations();
+    await MigrationRunner(
+      db: db,
+      loadMigrations: () async => migrations,
+    ).runAll();
+
+    docRepo = SqliteDocumentRepository(db);
+    pageRepo = SqlitePageRepository(db);
+    ftsSync = SqliteFtsSyncService(db);
+    
+    mockValidator = MockImportValidator();
+    mockFileStorage = MockDocumentFileStorage();
+    mockMetadataReader = MockPdfMetadataReader();
+
+    pipeline = DocumentPipelineImpl(
+      validator: mockValidator,
+      fileStorage: mockFileStorage,
+      metadataReader: mockMetadataReader,
+      documentRepository: docRepo,
+      pageRepository: pageRepo,
+      searchIndexSync: ftsSync,
+    );
+  });
+
+  tearDown(() {
+    rawDb.dispose();
+  });
+
+  test('imported document is immediately searchable via FTS', () async {
+    // Arrange
+    const sourcePath = '/tmp/test_document.pdf';
+    const storagePath = '/app/storage/uuid.pdf';
+    const pageCount = 1;
+    const documentTitle = 'test_document';
+
+    when(() => mockValidator.validateFile(sourcePath))
+        .thenAnswer((_) async => const PdfMetadata(pageCount: pageCount));
+    
+    when(() => mockFileStorage.storeForDocument(any(), sourcePath))
+        .thenAnswer((_) async {});
+    
+    when(() => mockFileStorage.pathForDocument(any()))
+        .thenReturn(storagePath);
+        
+    // Act
+    await pipeline.importFromPath(sourcePath);
+
+    // Assert: Verify FTS table is populated
+    // The FTS table `documents_fts` has columns `document_id` (unindexed) and `content`.
+    // We search across all indexed columns (i.e. content) using the table name match.
+    final result = rawDb.select('SELECT document_id FROM documents_fts WHERE documents_fts MATCH ?', [documentTitle]);
+    
+    expect(result.length, 1);
+  });
+}


### PR DESCRIPTION
### What changed
- Defined `SearchIndexSync` interface to decouple the import pipeline from specific FTS implementations.
- Implemented `SqliteFtsSyncService` to handle `documents_fts` updates using existing logic.
- Integrated FTS sync into `DocumentPipelineImpl` as a "best-effort" step at the end of the import process.
- Added a full integration test to verify that imported PDFs are immediately searchable in SQLite.

### Why it changed
Newly imported documents were missing from the search index until a manual sync occurred. This change ensures the FTS index is updated automatically after every successful import, satisfying the "immediate availability" requirement for Phase 2.

### How to test
1. Run the new integration test:
   `flutter test test/infrastructure/sqlite/document_pipeline_fts_test.dart`
2. Verify that the test passes and the document titles are found in the `documents_fts` table.

### Professional Checklist
- [x] Tests added usage of `SearchIndexSync` in pipeline unit tests
- [x] Added `document_pipeline_fts_test.dart` integration test
- [x] Linter passes
- [x] No debug logs left