### PR TITLE
docs: drafting ADR for file storage strategy

### DIFF
--- a/docs/decisions/0012-file-storage-strategy-for-imported-pdfs.md
+++ b/docs/decisions/0012-file-storage-strategy-for-imported-pdfs.md
@@ -31,3 +31,8 @@ Related decision: PDF metadata library selection is documented in `docs/decision
 - + Explicit cleanup semantics prevent orphan managed files and partial import state.
 - - Requires storage-root configuration and write-permission validation.
 - - May temporarily duplicate disk usage during import.
+
+## Implementation References
+
+- `DocumentFileStorage` / `LocalDocumentFileStorage`: [lib/infrastructure/file_storage/local_document_file_storage.dart](lib/infrastructure/file_storage/local_document_file_storage.dart)
+- `DocumentPipeline`: orchestrates the storage and cleanup logic.

--- a/docs/decisions/0013-pdf-library-choice-for-metadata.md
+++ b/docs/decisions/0013-pdf-library-choice-for-metadata.md
@@ -27,3 +27,7 @@ Related decision: imported file storage root/layout and cleanup semantics are do
 - - Adds native/plugin dependency surface and platform-specific runtime considerations.
 - - Malformed/encrypted PDFs may still fail metadata reads and must be mapped to typed validation/metadata errors.
 - - If future requirements need advanced PDF semantics, this decision may need revision in a follow-up ADR.
+
+## Implementation References
+
+- `PdfMetadataReader` / `PdfMetadataReaderImpl`: [lib/infrastructure/pdf/pdf_metadata_reader_impl.dart](lib/infrastructure/pdf/pdf_metadata_reader_impl.dart)

--- a/docs/pdf_import_pipeline.md
+++ b/docs/pdf_import_pipeline.md
@@ -49,7 +49,7 @@ The output of this phase is a correctly imported, internally tracked document re
 
 ## File Storage Strategy
 
-Imported PDFs are persisted in application-managed storage so document processing is independent from the original user-selected file location.
+Imported PDFs are persisted in application-managed storage so document processing is independent from the original user-selected file location. Detailed architectural decisions are documented in [docs/decisions/0012-file-storage-strategy-for-imported-pdfs.md](docs/decisions/0012-file-storage-strategy-for-imported-pdfs.md).
 
 ### Storage Root
 
@@ -190,7 +190,7 @@ Responsibilities:
 
 ### `PdfMetadataReader`
 
-Abstracts PDF metadata access used during import.
+Abstracts PDF metadata access used during import. The choice of underlying PDF library is documented in [docs/decisions/0013-pdf-library-choice-for-metadata.md](docs/decisions/0013-pdf-library-choice-for-metadata.md).
 
 Responsibilities:
 


### PR DESCRIPTION
## Purpose
This PR formally documents the architectural decisions for PDF file storage and metadata library selection as part of the Phase 2 PDF Input Pipeline.

## Changes
- **ADR 0012**: Defined file storage strategy (deterministic paths, copy-on-import, cleanup semantics) with links to `LocalDocumentFileStorage`.
- **ADR 0013**: Documented the selection of `pdfx` for metadata extraction with links to `PdfMetadataReaderImpl`.
- **Docs Update**: Cross-linked new ADRs within `docs/pdf_import_pipeline.md` for better traceability.

## Context
- **Milestone**: `v0.2 PDF Input Pipeline`
- **Issue**: Phase 2 – 9. Add ADRs for File Storage Strategy and PDF Library Choice

## Definition of Done
- [x] ADRs exist under `docs/decisions/`.
- [x] Content reflects implementation details and constraints.
- [x] Bidirectional links between pipeline docs and ADRs are verified.