### PR TITLE
Feat/add ocrengine interface and domain types ocrpageresult ocrinput errors

### DIFF
--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -13,11 +13,8 @@ export 'keyword.dart';
 export 'keyword_repository.dart';
 export 'ocr_engine.dart';
 export 'ocr_error.dart';
-
 export 'ocr_types.dart';
-
 export 'page.dart';
-
 export 'page_repository.dart';
 export 'pdf_metadata.dart';
 export 'place.dart';

--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -11,7 +11,9 @@ export 'import_configuration.dart';
 export 'import_validation_error.dart';
 export 'keyword.dart';
 export 'keyword_repository.dart';
+export 'ocr_types.dart';
 export 'page.dart';
+
 export 'page_repository.dart';
 export 'pdf_metadata.dart';
 export 'place.dart';

--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -11,7 +11,9 @@ export 'import_configuration.dart';
 export 'import_validation_error.dart';
 export 'keyword.dart';
 export 'keyword_repository.dart';
+export 'ocr_error.dart';
 export 'ocr_types.dart';
+
 export 'page.dart';
 
 export 'page_repository.dart';

--- a/lib/src/domain/domain.dart
+++ b/lib/src/domain/domain.dart
@@ -11,7 +11,9 @@ export 'import_configuration.dart';
 export 'import_validation_error.dart';
 export 'keyword.dart';
 export 'keyword_repository.dart';
+export 'ocr_engine.dart';
 export 'ocr_error.dart';
+
 export 'ocr_types.dart';
 
 export 'page.dart';

--- a/lib/src/domain/ocr_engine.dart
+++ b/lib/src/domain/ocr_engine.dart
@@ -1,0 +1,16 @@
+import 'ocr_types.dart';
+
+/// Defines the contract for an OCR (Optical Character Recognition) engine.
+///
+/// Implementations of this interface wrap specific OCR libraries or services
+/// (e.g., Apple Vision, Tesseract, Windows OCR) to provide a unified way
+/// to extract text from images.
+abstract class OCREngine {
+  /// Extracts text from the given [input].
+  ///
+  /// Returns a [Future] that completes with an [OcrPageResult] containing the
+  /// extracted text and optional confidence score.
+  ///
+  /// Throws an [OcrEngineError] if the extraction fails.
+  Future<OcrPageResult> extractText(OcrInput input);
+}

--- a/lib/src/domain/ocr_error.dart
+++ b/lib/src/domain/ocr_error.dart
@@ -1,0 +1,24 @@
+/// Base class for errors occurring within the OCR domain.
+///
+/// This allows the application to distinguish OCR-specific failures from other system errors.
+abstract class OcrError implements Exception {
+  const OcrError();
+  String get message;
+}
+
+/// Represents a failure in the underlying OCR engine.
+///
+/// This wraps any platform-specific errors or unexpected engine behavior.
+class OcrEngineError extends OcrError {
+  final String description;
+  final Object? originalError;
+
+  const OcrEngineError(this.description, [this.originalError]);
+
+  @override
+  String get message => 'OCR Engine failed: $description';
+
+  @override
+  String toString() =>
+      'OcrEngineError: $message${originalError != null ? ' (Cause: $originalError)' : ''}';
+}

--- a/lib/src/domain/ocr_types.dart
+++ b/lib/src/domain/ocr_types.dart
@@ -1,8 +1,8 @@
 /// Represents the input source for an OCR operation.
 ///
-/// This is a sealed class to allow for different types of inputs (e.g., file path,
+/// This allows for different types of inputs (e.g., file path,
 /// bytes, etc.) in a type-safe way.
-sealed class OcrInput {
+abstract class OcrInput {
   const OcrInput();
 }
 

--- a/lib/src/domain/ocr_types.dart
+++ b/lib/src/domain/ocr_types.dart
@@ -1,0 +1,59 @@
+/// Represents the input source for an OCR operation.
+///
+/// This is a sealed class to allow for different types of inputs (e.g., file path,
+/// bytes, etc.) in a type-safe way.
+sealed class OcrInput {
+  const OcrInput();
+}
+
+/// An OCR input that points to a file on the local filesystem.
+class FileOcrInput extends OcrInput {
+  final String filePath;
+
+  const FileOcrInput(this.filePath);
+
+  @override
+  String toString() => 'FileOcrInput(filePath: $filePath)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is FileOcrInput && other.filePath == filePath;
+  }
+
+  @override
+  int get hashCode => filePath.hashCode;
+}
+
+/// Represents the result of an OCR operation on a single page.
+class OcrPageResult {
+  /// The raw text extracted from the page.
+  ///
+  /// This is never null, but may be empty if no text was found.
+  final String rawText;
+
+  /// The confidence score of the extraction, from 0.0 to 1.0.
+  ///
+  /// This may be null if the underlying engine does not support confidence scores.
+  final double? confidence;
+
+  const OcrPageResult({
+    required this.rawText,
+    this.confidence,
+  });
+
+  @override
+  String toString() =>
+      'OcrPageResult(rawText: $rawText, confidence: $confidence)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is OcrPageResult &&
+        other.rawText == rawText &&
+        other.confidence == confidence;
+  }
+
+  @override
+  int get hashCode => Object.hash(rawText, confidence);
+}

--- a/test/unit/domain/ocr_engine_test.dart
+++ b/test/unit/domain/ocr_engine_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/src/domain/domain.dart';
+import 'package:personal_archive/src/domain/ocr_engine.dart';
+
+// Mock implementation to verify the interface contract
+class MockOcrEngine implements OCREngine {
+  @override
+  Future<OcrPageResult> extractText(OcrInput input) async {
+    if (input is FileOcrInput) {
+      if (input.filePath.contains('error')) {
+        throw const OcrEngineError('Mock failure');
+      }
+      return const OcrPageResult(rawText: 'Mock Text', confidence: 0.95);
+    }
+    return const OcrPageResult(rawText: '', confidence: 0.0);
+  }
+}
+
+void main() {
+  group('OCREngine Interface Contract', () {
+    test('can be implemented and return result', () async {
+      final engine = MockOcrEngine();
+      final result =
+          await engine.extractText(const FileOcrInput('/path/to/image.png'));
+
+      expect(result, isA<OcrPageResult>());
+      expect(result.rawText, 'Mock Text');
+      expect(result.confidence, 0.95);
+    });
+
+    test('can throw OcrEngineError', () async {
+      final engine = MockOcrEngine();
+      expect(
+        () => engine.extractText(const FileOcrInput('/path/to/error.png')),
+        throwsA(isA<OcrEngineError>()),
+      );
+    });
+
+    test('OcrInput equality', () {
+      const input1 = FileOcrInput('/path/a');
+      const input2 = FileOcrInput('/path/a');
+      const input3 = FileOcrInput('/path/b');
+
+      expect(input1, equals(input2));
+      expect(input1, isNot(equals(input3)));
+    });
+
+    test('OcrPageResult equality', () {
+      const res1 = OcrPageResult(rawText: 'A', confidence: 1.0);
+      const res2 = OcrPageResult(rawText: 'A', confidence: 1.0);
+      const res3 = OcrPageResult(rawText: 'B', confidence: 0.5);
+
+      expect(res1, equals(res2));
+      expect(res1, isNot(equals(res3)));
+    });
+  });
+}


### PR DESCRIPTION
# feat(domain): add OCREngine interface and domain types

## What changed
- Introduced `OcrInput` (abstract) and `FileOcrInput` to standardize OCR input sources.
- Created `OcrPageResult` to encapsulate extraction results (text + confidence).
- Added `OcrEngineError` to validly distinguish OCR failures from system errors.
- Defined the `OCREngine` abstract interface to decouple the application layer from specific OCR implementations.
- Exported all new types via `lib/src/domain/domain.dart`.
- Added unit tests in `test/unit/domain/ocr_engine_test.dart` to verify the contract.

## Why it changed
Closes #Phase3-Issue01

The pipeline requires a way to perform OCR without tightly coupling the core logic to platform-specific APIs (Windows Media OCR, Apple Vision, Tesseract). establishing this `OCREngine` contract allows us to:
1.  Develop the application layer against a stable interface.
2.  Swap underlying OCR implementations without affecting business logic.
3.  Mock OCR behavior for fast, reliable unit testing.

## How to test
1.  **Run specific unit tests:**
    ```bash
    flutter test test/unit/domain/ocr_engine_test.dart
    ```
2.  **Verify exports:** Check `lib/src/domain/domain.dart` to ensure no import errors exist in the project.

## Professional Checklist
- [x] Tests added/updated (Verified contract via `MockOcrEngine`)
- [x] Documentation updated (Code comments on public APIs)
- [x] Linter/Formatter passes
- [x] No debug logs or "TODOs" left in code