### PR TITLE
Feat/add pagerepositoryupdate for ocr results

### DIFF
--- a/lib/infrastructure/sqlite/sqlite_page_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_page_repository.dart
@@ -74,22 +74,30 @@ class SqlitePageRepository implements PageRepository {
       operation: 'update_page',
       table: 'pages',
       recordCount: 1,
-      action: () => _db.execute(
-        '''
-        UPDATE pages
-        SET raw_text = ?,
-            processed_text = ?,
-            ocr_confidence = ?
-        WHERE id = ?
-        ''',
-        [
-          page.rawText,
-          page.processedText,
-          page.ocrConfidence,
-          page.id,
-        ],
-      ),
-    ).catchError((error, _) {
+      action: () async {
+        await _db.execute(
+          '''
+          UPDATE pages
+          SET raw_text = ?,
+              processed_text = ?,
+              ocr_confidence = ?
+          WHERE id = ?
+          ''',
+          [
+            page.rawText,
+            page.processedText,
+            page.ocrConfidence,
+            page.id,
+          ],
+        );
+        final rows = await _db.query('SELECT changes() AS count');
+        final affected = rows.firstOrNull?['count'] as int? ?? 0;
+        if (affected == 0) {
+          throw StorageNotFoundError(resource: 'Page', id: page.id);
+        }
+      },
+    ).catchError((Object error, StackTrace _) {
+      if (error is StorageError) throw error;
       throw StorageUnknownError(error);
     });
   }

--- a/test/infrastructure/sqlite/sqlite_page_repository_integration_test.dart
+++ b/test/infrastructure/sqlite/sqlite_page_repository_integration_test.dart
@@ -190,5 +190,87 @@ void main() {
       expect(result, isNotNull);
       expect(result, isEmpty);
     });
+
+    test(
+      'update persists rawText and ocrConfidence against real schema',
+      () async {
+        const documentId = 'doc-for-update-integration';
+        final epoch = DateTime.now().toUtc().millisecondsSinceEpoch;
+
+        await db.execute(
+          '''
+          INSERT INTO documents (
+            id, title, file_path, status, confidence_score,
+            place_id, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          ''',
+          [
+            documentId,
+            'Integration Doc',
+            '/path/doc.pdf',
+            DocumentStatus.imported.name,
+            null,
+            null,
+            epoch,
+            epoch,
+          ],
+        );
+
+        final original = Page(
+          id: 'page-integration-update',
+          documentId: documentId,
+          pageNumber: 1,
+          rawText: null,
+          processedText: null,
+          ocrConfidence: null,
+        );
+        await repo.insertAll([original]);
+
+        final updated = Page(
+          id: original.id,
+          documentId: original.documentId,
+          pageNumber: original.pageNumber,
+          rawText: 'ocr extracted text',
+          processedText: null,
+          ocrConfidence: 0.88,
+        );
+        await repo.update(updated);
+
+        final found = await repo.findByDocumentId(documentId);
+        expect(found, hasLength(1));
+
+        final result = found.first;
+        expect(result.rawText, 'ocr extracted text');
+        expect(result.ocrConfidence, closeTo(0.88, 1e-9));
+        expect(result.id, original.id);
+        expect(result.documentId, original.documentId);
+        expect(result.pageNumber, original.pageNumber);
+      },
+    );
+
+    test(
+      'update throws StorageNotFoundError for non-existent page against real schema',
+      () async {
+        final ghost = Page(
+          id: 'integration-ghost-page',
+          documentId: 'any-doc',
+          pageNumber: 1,
+          rawText: 'text',
+          processedText: null,
+          ocrConfidence: 0.9,
+        );
+
+        await expectLater(
+          () => repo.update(ghost),
+          throwsA(
+            isA<StorageNotFoundError>().having(
+              (e) => e.id,
+              'id',
+              ghost.id,
+            ),
+          ),
+        );
+      },
+    );
   });
 }

--- a/test/infrastructure/sqlite/sqlite_page_repository_test.dart
+++ b/test/infrastructure/sqlite/sqlite_page_repository_test.dart
@@ -207,6 +207,31 @@ void main() {
         expect(result.pageNumber, original.pageNumber);
       },
     );
+
+    test(
+      'update throws StorageNotFoundError when page does not exist',
+      () async {
+        final ghost = Page(
+          id: 'non-existent-page',
+          documentId: 'any-doc',
+          pageNumber: 1,
+          rawText: 'text',
+          processedText: null,
+          ocrConfidence: 0.9,
+        );
+
+        await expectLater(
+          () => repo.update(ghost),
+          throwsA(
+            isA<StorageNotFoundError>().having(
+              (e) => e.id,
+              'id',
+              ghost.id,
+            ),
+          ),
+        );
+      },
+    );
   });
 }
 

--- a/test/infrastructure/sqlite/sqlite_page_repository_test.dart
+++ b/test/infrastructure/sqlite/sqlite_page_repository_test.dart
@@ -149,6 +149,64 @@ void main() {
         );
       },
     );
+
+    test(
+      'update persists rawText and ocrConfidence while leaving id, documentId, and pageNumber unchanged',
+      () async {
+        const documentId = 'doc-for-update';
+
+        await db.execute(
+          '''
+          INSERT INTO documents (
+            id, title, file_path, status, confidence_score,
+            place_id, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          ''',
+          [
+            documentId,
+            'Doc Title',
+            '/path/to/doc.pdf',
+            DocumentStatus.imported.name,
+            null,
+            null,
+            0,
+            0,
+          ],
+        );
+
+        final original = Page(
+          id: 'page-to-update',
+          documentId: documentId,
+          pageNumber: 1,
+          rawText: null,
+          processedText: null,
+          ocrConfidence: null,
+        );
+        await repo.insertAll([original]);
+
+        final updated = Page(
+          id: original.id,
+          documentId: original.documentId,
+          pageNumber: original.pageNumber,
+          rawText: 'extracted text',
+          processedText: null,
+          ocrConfidence: 0.95,
+        );
+        await repo.update(updated);
+
+        final found = await repo.findByDocumentId(documentId);
+        expect(found, hasLength(1));
+
+        final result = found.first;
+        // Mutable fields changed.
+        expect(result.rawText, 'extracted text');
+        expect(result.ocrConfidence, closeTo(0.95, 1e-9));
+        // Immutable fields untouched.
+        expect(result.id, original.id);
+        expect(result.documentId, original.documentId);
+        expect(result.pageNumber, original.pageNumber);
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## What

`PageRepository` had no way to persist OCR results after processing. This adds the `update` method end-to-end — domain contract, SQLite implementation with a proper no-row guard, and test coverage at both unit and integration level.

## Why

The OCR pipeline needs to write `rawText` and `ocrConfidence` back to the `pages` table after each page is processed. Without this, it would have had to delete and re-insert rows, which breaks page ID immutability.

## Changes

- `PageRepository` declares `Future<void> update(Page page)`
- `SqlitePageRepository` executes the UPDATE and checks `changes()` — throws `StorageNotFoundError` if no row matched
- Unit tests: happy path (fields updated, immutable fields untouched) + error path (missing page)
- Integration tests: same two cases against the fully migrated in-memory schema

## Notes

- No schema migration needed — `raw_text` and `ocr_confidence` columns already exist from Phase 1
- `id`, `document_id`, and `page_number` are never touched by the UPDATE
