### PR TITLE
Feat/implement macos ocr adapter ocrengine

### DIFF
--- a/docs/decisions/0016-platform-conditional-compilation.md
+++ b/docs/decisions/0016-platform-conditional-compilation.md
@@ -57,3 +57,81 @@ We will use **conditional imports** (also known as "stubbing") to isolate platfo
 - **Build Safety**: Prevents "symbol not found" errors during linking/compilation.
 - **Maintainability**: Clear separation of platform logic.
 - **Testing**: Allows easy injection of a mock engine for unit tests without loading native libraries.
+
+## Addendum — macOS Vision OCR Implementation (2026-02-23)
+
+The first concrete platform adapter has been implemented following the strategy
+above. This section records the details for future maintainers.
+
+### Method Channel Contract
+
+| Property | Value |
+|---|---|
+| Channel name | `personal_archive/ocr` |
+| Method | `recognizeText` |
+
+**Arguments** (map — exactly one of the two keys must be present):
+
+| Key | Type | Description |
+|---|---|---|
+| `filePath` | `String` | Absolute path to an image file on disk. Preferred for large images to avoid copying bytes across the channel boundary. |
+| `imageBytes` | `Uint8List` (via `FlutterStandardTypedData`) | Raw image bytes (PNG, JPEG, TIFF, or any format `CGImageSource` can decode). |
+
+**Return value** (map):
+
+| Key | Type | Description |
+|---|---|---|
+| `text` | `String` | Concatenated recognised text, observations joined by `\n`. Empty string if no text was found. |
+| `confidence` | `Double?` | Mean per-observation confidence (0.0–1.0), or `null` when no observations were produced. |
+
+**Error codes** (returned as `FlutterError`):
+
+| Code | Meaning |
+|---|---|
+| `INVALID_ARGUMENTS` | Neither or both of `filePath`/`imageBytes` supplied, or arguments are not a map. |
+| `IMAGE_LOAD_FAILED` | The image could not be decoded to a `CGImage`. |
+| `OCR_FAILED` | `VNRecognizeTextRequest` or its handler failed. |
+
+### Native Implementation (`macos/Runner/VisionOcrPlugin.swift`)
+
+- Registers on the channel in `MainFlutterWindow.awakeFromNib()` via
+  `VisionOcrPlugin.register(with:)`.
+- Uses `VNRecognizeTextRequest` with `recognitionLevel = .accurate` and
+  `usesLanguageCorrection = true`.
+- Vision work is dispatched to `DispatchQueue.global(qos: .userInitiated)`;
+  results are returned on the main thread as required by Flutter.
+- Supported image formats: anything `CGImageSourceCreateWithURL` /
+  `CGImageSourceCreateWithData` can load — PNG, JPEG, TIFF, BMP, GIF, HEIF.
+
+### Deployment Target
+
+The macOS deployment target is **10.15** (Catalina), which is the minimum
+version supporting `VNRecognizeTextRequest`. No additional capability
+entitlements are required.
+
+### Dart Adapter (`lib/infrastructure/ocr/ocr_engine_macos.dart`)
+
+- `MacOSOcrEngine` implements `OCREngine`.
+- Accepts an optional `MethodChannel` in the constructor for test injection.
+- Maps `FileOcrInput` → `filePath` argument, `MemoryOcrInput` → `imageBytes`
+  argument.
+- Catches `PlatformException` and rethrows as `OcrEngineError` with the
+  original exception attached.
+
+### Conditional Import Wiring
+
+```
+ocr_engine_factory.dart          ← public entry point
+  └─ exports ocr_engine_stub.dart        (fallback — throws OcrEngineError)
+     if (dart.library.io) ocr_engine_io.dart
+       └─ checks Platform.isMacOS at runtime
+          └─ delegates to ocr_engine_macos.dart → MacOSOcrEngine
+```
+
+### Recommended OcrInput Strategy
+
+For large images (e.g. rendered PDF pages at 300 DPI), prefer `FileOcrInput`
+over `MemoryOcrInput` to avoid copying megabytes of pixel data across the
+method-channel boundary. `PdfPageImageRendererImpl` currently produces
+`MemoryOcrInput`; a future optimisation could write to a temp file and use
+`FileOcrInput` instead.

--- a/lib/infrastructure/ocr/ocr_engine_factory.dart
+++ b/lib/infrastructure/ocr/ocr_engine_factory.dart
@@ -1,0 +1,13 @@
+/// Platform-conditional OCR engine factory.
+///
+/// On dart:io targets (macOS, Windows, Linux) this resolves to
+/// `ocr_engine_io.dart`, which inspects the OS at runtime.
+/// On non-IO targets (web) the stub is used instead.
+///
+/// Usage:
+/// ```dart
+/// import 'package:personal_archive/infrastructure/ocr/ocr_engine_factory.dart';
+///
+/// final engine = createOcrEngine();
+/// ```
+export 'ocr_engine_stub.dart' if (dart.library.io) 'ocr_engine_io.dart';

--- a/lib/infrastructure/ocr/ocr_engine_io.dart
+++ b/lib/infrastructure/ocr/ocr_engine_io.dart
@@ -1,0 +1,17 @@
+import 'dart:io' show Platform;
+
+import 'package:personal_archive/infrastructure/ocr/ocr_engine_macos.dart'
+    as macos;
+import 'package:personal_archive/src/domain/ocr_engine.dart';
+import 'package:personal_archive/src/domain/ocr_error.dart';
+
+/// Creates the platform-appropriate [OCREngine] on dart:io targets.
+///
+/// Currently only macOS is supported (via [macos.MacOSOcrEngine]).
+/// Other platforms throw [OcrEngineError].
+OCREngine createOcrEngine() {
+  if (Platform.isMacOS) {
+    return macos.createOcrEngine();
+  }
+  throw const OcrEngineError('OCR is not available on this platform');
+}

--- a/lib/infrastructure/ocr/ocr_engine_macos.dart
+++ b/lib/infrastructure/ocr/ocr_engine_macos.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/services.dart';
+import 'package:personal_archive/src/domain/ocr_engine.dart';
+import 'package:personal_archive/src/domain/ocr_error.dart';
+import 'package:personal_archive/src/domain/ocr_types.dart';
+
+/// macOS implementation of [OCREngine] backed by Apple Vision.
+///
+/// Communicates with the native `VisionOcrPlugin` over a
+/// [MethodChannel] named `personal_archive/ocr`.
+///
+/// Supports both [FileOcrInput] (preferred — avoids copying bytes across the
+/// channel) and [MemoryOcrInput].
+class MacOSOcrEngine implements OCREngine {
+  /// Creates a [MacOSOcrEngine].
+  ///
+  /// An optional [channel] can be injected for testing; otherwise the default
+  /// production channel is used.
+  MacOSOcrEngine({MethodChannel? channel})
+      : _channel = channel ?? const MethodChannel('personal_archive/ocr');
+
+  final MethodChannel _channel;
+
+  @override
+  Future<OcrPageResult> extractText(OcrInput input) async {
+    final Map<String, dynamic> args;
+
+    if (input is FileOcrInput) {
+      args = <String, dynamic>{'filePath': input.filePath};
+    } else if (input is MemoryOcrInput) {
+      args = <String, dynamic>{'imageBytes': input.bytes};
+    } else {
+      throw OcrEngineError(
+        'Unsupported OcrInput type: ${input.runtimeType}',
+      );
+    }
+
+    try {
+      final result = await _channel.invokeMapMethod<String, dynamic>(
+        'recognizeText',
+        args,
+      );
+
+      if (result == null) {
+        throw const OcrEngineError(
+          'Native OCR returned null — unexpected channel response',
+        );
+      }
+
+      final text = result['text'] as String? ?? '';
+      final confidence = result['confidence'] as double?;
+
+      return OcrPageResult(rawText: text, confidence: confidence);
+    } on PlatformException catch (e) {
+      throw OcrEngineError(
+        e.message ?? 'Unknown platform error during OCR',
+        e,
+      );
+    }
+  }
+}
+
+/// Factory function matching the signature expected by the conditional-import
+/// wiring in `ocr_engine_factory.dart`.
+OCREngine createOcrEngine() => MacOSOcrEngine();

--- a/lib/infrastructure/ocr/ocr_engine_stub.dart
+++ b/lib/infrastructure/ocr/ocr_engine_stub.dart
@@ -1,0 +1,18 @@
+import 'package:personal_archive/src/domain/ocr_engine.dart';
+import 'package:personal_archive/src/domain/ocr_error.dart';
+import 'package:personal_archive/src/domain/ocr_types.dart';
+
+/// Fallback OCR engine for platforms without a native OCR implementation.
+///
+/// This stub is selected via conditional imports on platforms that do not
+/// have a native adapter (e.g. web, Linux). Every method throws immediately.
+class StubOcrEngine implements OCREngine {
+  @override
+  Future<OcrPageResult> extractText(OcrInput input) {
+    throw const OcrEngineError('OCR is not available on this platform');
+  }
+}
+
+/// Factory function matching the signature expected by the conditional-import
+/// wiring in `ocr_engine_factory.dart`.
+OCREngine createOcrEngine() => StubOcrEngine();

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
+		7A1E2F3B2044C0000003C045 /* VisionOcrPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1E2F3A2044C0000003C045 /* VisionOcrPlugin.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
@@ -61,6 +62,7 @@
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		33CC10F72044A3C60003C045 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Runner/Info.plist; sourceTree = "<group>"; };
 		33CC11122044BFA00003C045 /* MainFlutterWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFlutterWindow.swift; sourceTree = "<group>"; };
+		7A1E2F3A2044C0000003C045 /* VisionOcrPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisionOcrPlugin.swift; sourceTree = "<group>"; };
 		33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Debug.xcconfig"; sourceTree = "<group>"; };
 		33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Release.xcconfig"; sourceTree = "<group>"; };
 		33CEB47722A0578A004F2AC0 /* Flutter-Generated.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Flutter-Generated.xcconfig"; path = "ephemeral/Flutter-Generated.xcconfig"; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 			children = (
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
+				7A1E2F3A2044C0000003C045 /* VisionOcrPlugin.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
 				33E51914231749380026EE4D /* Release.entitlements */,
 				33CC11242044D66E0003C045 /* Resources */,
@@ -341,6 +344,7 @@
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
+				7A1E2F3B2044C0000003C045 /* VisionOcrPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -10,6 +10,10 @@ class MainFlutterWindow: NSWindow {
 
     RegisterGeneratedPlugins(registry: flutterViewController)
 
+    // Register app-level plugins that are not auto-generated.
+    let registrar = flutterViewController.registrar(forPlugin: "VisionOcrPlugin")
+    VisionOcrPlugin.register(with: registrar)
+
     super.awakeFromNib()
   }
 }

--- a/macos/Runner/VisionOcrPlugin.swift
+++ b/macos/Runner/VisionOcrPlugin.swift
@@ -1,0 +1,187 @@
+import Cocoa
+import FlutterMacOS
+import Vision
+
+/// Flutter method-channel plugin that exposes Apple Vision text recognition
+/// to the Dart side.
+///
+/// Channel: `personal_archive/ocr`
+///
+/// ## Methods
+///
+/// ### `recognizeText`
+///
+/// **Arguments** (map):
+/// - `filePath` (`String`, optional) – path to an image file on disk.
+/// - `imageBytes` (`FlutterStandardTypedData`, optional) – raw image bytes
+///   (PNG, JPEG, TIFF, or any format loadable by `CGImageSource`).
+///
+/// Exactly one of the two must be provided.
+///
+/// **Returns** (map):
+/// - `text` (`String`) – the concatenated recognised text.
+/// - `confidence` (`Double?`) – mean per-observation confidence (0.0–1.0),
+///   or `nil` if unavailable.
+///
+/// **Errors** (`FlutterError`):
+/// - `INVALID_ARGUMENTS` – neither or both input keys supplied.
+/// - `IMAGE_LOAD_FAILED` – the image could not be decoded to a `CGImage`.
+/// - `OCR_FAILED` – Vision request failed.
+class VisionOcrPlugin {
+  static let channelName = "personal_archive/ocr"
+
+  /// Registers this plugin on the given [registrar].
+  static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(
+      name: channelName,
+      binaryMessenger: registrar.messenger
+    )
+    let instance = VisionOcrPlugin()
+    channel.setMethodCallHandler(instance.handle)
+  }
+
+  // MARK: - Method dispatch
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "recognizeText":
+      handleRecognizeText(call, result: result)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  // MARK: - recognizeText
+
+  private func handleRecognizeText(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard let args = call.arguments as? [String: Any] else {
+      result(FlutterError(
+        code: "INVALID_ARGUMENTS",
+        message: "Arguments must be a map",
+        details: nil
+      ))
+      return
+    }
+
+    let filePath = args["filePath"] as? String
+    let imageBytes = args["imageBytes"] as? FlutterStandardTypedData
+
+    guard (filePath != nil) != (imageBytes != nil) else {
+      result(FlutterError(
+        code: "INVALID_ARGUMENTS",
+        message: "Provide exactly one of 'filePath' or 'imageBytes'",
+        details: nil
+      ))
+      return
+    }
+
+    // Load CGImage
+    let cgImage: CGImage
+    do {
+      if let path = filePath {
+        cgImage = try loadImageFromFile(path)
+      } else {
+        cgImage = try loadImageFromBytes(imageBytes!.data)
+      }
+    } catch {
+      result(FlutterError(
+        code: "IMAGE_LOAD_FAILED",
+        message: "Could not decode image: \(error.localizedDescription)",
+        details: nil
+      ))
+      return
+    }
+
+    // Run Vision on a background queue so we never block the platform thread.
+    let workItem = DispatchWorkItem { [weak self] in
+      self?.recognizeText(in: cgImage, result: result)
+    }
+    DispatchQueue.global(qos: .userInitiated).async(execute: workItem)
+  }
+
+  // MARK: - Image loading helpers
+
+  private func loadImageFromFile(_ path: String) throws -> CGImage {
+    let url = URL(fileURLWithPath: path)
+    guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+          let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+      throw NSError(
+        domain: "VisionOcrPlugin",
+        code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "Failed to load image at \(path)"]
+      )
+    }
+    return image
+  }
+
+  private func loadImageFromBytes(_ data: Data) throws -> CGImage {
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+          let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+      throw NSError(
+        domain: "VisionOcrPlugin",
+        code: 2,
+        userInfo: [NSLocalizedDescriptionKey: "Failed to decode image from bytes"]
+      )
+    }
+    return image
+  }
+
+  // MARK: - Vision text recognition
+
+  private func recognizeText(in image: CGImage, result: @escaping FlutterResult) {
+    let request = VNRecognizeTextRequest { request, error in
+      if let error = error {
+        DispatchQueue.main.async {
+          result(FlutterError(
+            code: "OCR_FAILED",
+            message: "Vision text recognition failed: \(error.localizedDescription)",
+            details: nil
+          ))
+        }
+        return
+      }
+
+      guard let observations = request.results as? [VNRecognizedTextObservation] else {
+        DispatchQueue.main.async {
+          result(["text": "", "confidence": nil] as [String: Any?])
+        }
+        return
+      }
+
+      var lines: [String] = []
+      var totalConfidence: Float = 0
+
+      for observation in observations {
+        if let candidate = observation.topCandidates(1).first {
+          lines.append(candidate.string)
+          totalConfidence += candidate.confidence
+        }
+      }
+
+      let text = lines.joined(separator: "\n")
+      let meanConfidence: Double? = observations.isEmpty
+        ? nil
+        : Double(totalConfidence / Float(observations.count))
+
+      DispatchQueue.main.async {
+        result(["text": text, "confidence": meanConfidence] as [String: Any?])
+      }
+    }
+
+    request.recognitionLevel = VNRequestTextRecognitionLevel.accurate
+    request.usesLanguageCorrection = true
+
+    let handler = VNImageRequestHandler(cgImage: image, options: [:])
+    do {
+      try handler.perform([request])
+    } catch {
+      DispatchQueue.main.async {
+        result(FlutterError(
+          code: "OCR_FAILED",
+          message: "Vision request handler failed: \(error.localizedDescription)",
+          details: nil
+        ))
+      }
+    }
+  }
+}

--- a/test/infrastructure/ocr/ocr_engine_macos_test.dart
+++ b/test/infrastructure/ocr/ocr_engine_macos_test.dart
@@ -1,0 +1,175 @@
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/ocr/ocr_engine_macos.dart';
+import 'package:personal_archive/src/domain/ocr_error.dart';
+import 'package:personal_archive/src/domain/ocr_types.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MethodChannel channel;
+  late MacOSOcrEngine engine;
+
+  setUp(() {
+    channel = const MethodChannel('personal_archive/ocr');
+    engine = MacOSOcrEngine(channel: channel);
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  /// Installs a mock handler that returns the given [response] map.
+  void mockChannelSuccess(Map<String, dynamic> response) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      expect(call.method, equals('recognizeText'));
+      return response;
+    });
+  }
+
+  /// Installs a mock handler that throws a [PlatformException].
+  void mockChannelError({
+    required String code,
+    String? message,
+  }) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      throw PlatformException(code: code, message: message);
+    });
+  }
+
+  group('MacOSOcrEngine', () {
+    group('extractText with FileOcrInput', () {
+      test('returns text and confidence from channel', () async {
+        mockChannelSuccess({
+          'text': 'Hello World',
+          'confidence': 0.92,
+        });
+
+        final result = await engine.extractText(
+          const FileOcrInput('/path/to/image.png'),
+        );
+
+        expect(result.rawText, equals('Hello World'));
+        expect(result.confidence, closeTo(0.92, 0.001));
+      });
+
+      test('sends filePath argument to channel', () async {
+        String? receivedPath;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (MethodCall call) async {
+          final args = call.arguments as Map;
+          receivedPath = args['filePath'] as String?;
+          expect(args.containsKey('imageBytes'), isFalse);
+          return <String, dynamic>{'text': '', 'confidence': null};
+        });
+
+        await engine.extractText(const FileOcrInput('/tmp/test.png'));
+        expect(receivedPath, equals('/tmp/test.png'));
+      });
+    });
+
+    group('extractText with MemoryOcrInput', () {
+      test('returns text and confidence from channel', () async {
+        mockChannelSuccess({
+          'text': 'Memory OCR result',
+          'confidence': 0.85,
+        });
+
+        final bytes = Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]);
+        final result = await engine.extractText(MemoryOcrInput(bytes));
+
+        expect(result.rawText, equals('Memory OCR result'));
+        expect(result.confidence, closeTo(0.85, 0.001));
+      });
+
+      test('sends imageBytes argument to channel', () async {
+        Uint8List? receivedBytes;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (MethodCall call) async {
+          final args = call.arguments as Map;
+          receivedBytes = args['imageBytes'] as Uint8List?;
+          expect(args.containsKey('filePath'), isFalse);
+          return <String, dynamic>{'text': '', 'confidence': null};
+        });
+
+        final bytes = Uint8List.fromList([1, 2, 3, 4]);
+        await engine.extractText(MemoryOcrInput(bytes));
+        expect(receivedBytes, equals(bytes));
+      });
+    });
+
+    group('confidence handling', () {
+      test('maps null confidence from channel', () async {
+        mockChannelSuccess({
+          'text': 'No confidence',
+          'confidence': null,
+        });
+
+        final result = await engine.extractText(
+          const FileOcrInput('/path/to/image.png'),
+        );
+
+        expect(result.rawText, equals('No confidence'));
+        expect(result.confidence, isNull);
+      });
+    });
+
+    group('error handling', () {
+      test('wraps PlatformException as OcrEngineError', () async {
+        mockChannelError(code: 'OCR_FAILED', message: 'Vision failed');
+
+        expect(
+          () => engine.extractText(const FileOcrInput('/bad/image.png')),
+          throwsA(
+            isA<OcrEngineError>()
+                .having((e) => e.message, 'message', contains('Vision failed'))
+                .having(
+                    (e) => e.originalError, 'originalError',
+                    isA<PlatformException>()),
+          ),
+        );
+      });
+
+      test('wraps PlatformException with null message', () async {
+        mockChannelError(code: 'IMAGE_LOAD_FAILED');
+
+        expect(
+          () => engine.extractText(const FileOcrInput('/bad/image.png')),
+          throwsA(
+            isA<OcrEngineError>().having(
+              (e) => e.message,
+              'message',
+              contains('Unknown platform error'),
+            ),
+          ),
+        );
+      });
+
+      test('throws OcrEngineError for unsupported OcrInput subtype', () {
+        final unsupported = _UnknownOcrInput();
+
+        expect(
+          () => engine.extractText(unsupported),
+          throwsA(
+            isA<OcrEngineError>().having(
+              (e) => e.message,
+              'message',
+              contains('Unsupported OcrInput type'),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}
+
+/// A custom [OcrInput] subclass that is intentionally not handled
+/// by [MacOSOcrEngine] to test the unsupported-type error path.
+class _UnknownOcrInput extends OcrInput {
+  const _UnknownOcrInput();
+}

--- a/test/infrastructure/ocr/ocr_engine_stub_test.dart
+++ b/test/infrastructure/ocr/ocr_engine_stub_test.dart
@@ -1,0 +1,42 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/infrastructure/ocr/ocr_engine_stub.dart';
+import 'package:personal_archive/src/domain/ocr_error.dart';
+import 'package:personal_archive/src/domain/ocr_types.dart';
+
+void main() {
+  group('StubOcrEngine', () {
+    test('extractText throws OcrEngineError', () {
+      final engine = StubOcrEngine();
+
+      expect(
+        () => engine.extractText(const FileOcrInput('/any/image.png')),
+        throwsA(isA<OcrEngineError>().having(
+          (e) => e.message,
+          'message',
+          contains('not available on this platform'),
+        )),
+      );
+    });
+
+    test('extractText throws for MemoryOcrInput as well', () {
+      final engine = StubOcrEngine();
+      final input = MemoryOcrInput(
+        Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]),
+      );
+
+      expect(
+        () => engine.extractText(input),
+        throwsA(isA<OcrEngineError>()),
+      );
+    });
+  });
+
+  group('createOcrEngine', () {
+    test('returns a StubOcrEngine', () {
+      final engine = createOcrEngine();
+      expect(engine, isA<StubOcrEngine>());
+    });
+  });
+}


### PR DESCRIPTION
## What changed

Implement the macOS OCR adapter behind conditional imports so the pipeline can run real text recognition on macOS via Apple Vision.

- `StubOcrEngine` — fallback that throws `OcrEngineError` on unsupported platforms
- `VisionOcrPlugin` (Swift) — native bridge using `VNRecognizeTextRequest` with `.accurate` recognition level, registered on the `personal_archive/ocr` method channel
- `MacOSOcrEngine` — Dart adapter that dispatches `FileOcrInput`/`MemoryOcrInput` to the native side and maps results to `OcrPageResult`
- `ocr_engine_factory.dart` — conditional export selecting `ocr_engine_io.dart` (dart:io) or `ocr_engine_stub.dart` (fallback); IO variant checks `Platform.isMacOS` at runtime
- 11 new unit tests covering both adapter and stub
- ADR 0016 addendum documenting the channel contract, Vision config, and input strategy

## Why it changed

ADR 0004 mandates native Apple OCR on macOS. Without a real `OCREngine` implementation the pipeline can only use the mock. This PR closes that gap while keeping non-macOS builds unaffected via conditional compilation (ADR 0016).

## How to test

```bash
# All Dart tests (120 total, 11 new)
flutter test

# macOS build verification
flutter build macos --debug

```
## Checklist

- [ ]  Tests added/updated
- [ ]  Documentation updated (ADR 0016 addendum)
- [ ]  Linter/Formatter passes
- [ ]  No debug logs or TODOs left in code