### PR TITLE
Test/unit tests for ocr pipeline stage

### DIFF
--- a/test/application/document_pipeline_ocr_test.dart
+++ b/test/application/document_pipeline_ocr_test.dart
@@ -132,5 +132,36 @@ void main() {
       verifyNever(() => mockOcrEngine.extractText(any()));
       verifyNever(() => mockDocumentRepository.update(any()));
     });
+
+    // -------------------------------------------------------------------------
+    // Guard: invalid document state
+    // -------------------------------------------------------------------------
+
+    for (final status in [
+      DocumentStatus.processing,
+      DocumentStatus.completed,
+      DocumentStatus.failed,
+    ]) {
+      test('throws InvalidDocumentStateError when document is $status', () async {
+        when(() => mockDocumentRepository.findById(any()))
+            .thenAnswer((_) async => makeDocument(status: status));
+
+        await expectLater(
+          () => pipeline.runOcrForDocument('doc-1'),
+          throwsA(
+            isA<InvalidDocumentStateError>().having(
+              (e) => e.currentStatus,
+              'currentStatus',
+              status,
+            ),
+          ),
+        );
+
+        verify(() => mockDocumentRepository.findById('doc-1')).called(1);
+        verifyNever(() => mockRenderer.renderPage(any(), any()));
+        verifyNever(() => mockOcrEngine.extractText(any()));
+        verifyNever(() => mockDocumentRepository.update(any()));
+      });
+    }
   });
 }

--- a/test/application/document_pipeline_ocr_test.dart
+++ b/test/application/document_pipeline_ocr_test.dart
@@ -15,6 +15,7 @@ import 'package:personal_archive/src/domain/ocr_types.dart';
 import 'package:personal_archive/src/domain/page.dart';
 import 'package:personal_archive/src/application/ocr_pipeline_errors.dart';
 import 'package:personal_archive/src/application/ocr_result.dart';
+import 'package:personal_archive/src/domain/ocr_error.dart';
 import 'package:personal_archive/src/domain/page_repository.dart';
 
 // ---------------------------------------------------------------------------
@@ -243,6 +244,58 @@ void main() {
       verify(() => mockSearchIndexSync.syncDocument(docId)).called(1);
       // All 3 pages must have been updated before sync fires.
       verify(() => mockPageRepository.update(any())).called(3);
+    });
+
+    // -------------------------------------------------------------------------
+    // OCR engine failure
+    // -------------------------------------------------------------------------
+
+    test('sets document to failed and throws OcrEnginePipelineError when engine fails on page K', () async {
+      const docId = 'doc-1';
+      final doc = makeDocument(id: docId);
+      final pages = makePages(3, documentId: docId);
+      final ocrInput = MemoryOcrInput(Uint8List(4));
+      const successResult = OcrPageResult(rawText: 'ok', confidence: 0.9);
+
+      when(() => mockDocumentRepository.findById(docId))
+          .thenAnswer((_) async => doc);
+      when(() => mockDocumentRepository.update(any()))
+          .thenAnswer((inv) async => inv.positionalArguments.first as Document);
+      when(() => mockPageRepository.findByDocumentId(docId))
+          .thenAnswer((_) async => pages);
+      when(() => mockRenderer.renderPage(any(), any()))
+          .thenAnswer((_) async => ocrInput);
+      when(() => mockPageRepository.update(any())).thenAnswer((_) async {});
+
+      // Engine succeeds on page 1, throws on page 2 (K=2).
+      var engineCallCount = 0;
+      when(() => mockOcrEngine.extractText(any())).thenAnswer((_) async {
+        engineCallCount++;
+        if (engineCallCount == 2) {
+          throw const OcrEngineError('engine exploded');
+        }
+        return successResult;
+      });
+
+      await expectLater(
+        () => pipeline.runOcrForDocument(docId),
+        throwsA(
+          isA<OcrEnginePipelineError>().having(
+            (e) => e.pageNumber,
+            'pageNumber',
+            2,
+          ),
+        ),
+      );
+
+      // Document must be marked failed.
+      final capturedDocs = verify(
+        () => mockDocumentRepository.update(captureAny()),
+      ).captured.cast<Document>();
+      expect(capturedDocs.last.status, DocumentStatus.failed);
+
+      // FTS sync must NOT be called on failure.
+      verifyNever(() => mockSearchIndexSync.syncDocument(any()));
     });
   });
 }

--- a/test/application/document_pipeline_ocr_test.dart
+++ b/test/application/document_pipeline_ocr_test.dart
@@ -14,6 +14,7 @@ import 'package:personal_archive/src/domain/ocr_engine.dart';
 import 'package:personal_archive/src/domain/ocr_types.dart';
 import 'package:personal_archive/src/domain/page.dart';
 import 'package:personal_archive/src/application/ocr_pipeline_errors.dart';
+import 'package:personal_archive/src/application/ocr_result.dart';
 import 'package:personal_archive/src/domain/page_repository.dart';
 
 // ---------------------------------------------------------------------------
@@ -163,5 +164,54 @@ void main() {
         verifyNever(() => mockDocumentRepository.update(any()));
       });
     }
+
+    // -------------------------------------------------------------------------
+    // Success path
+    // -------------------------------------------------------------------------
+
+    test('updates status to completed and each page with OCR results', () async {
+      const docId = 'doc-1';
+      final doc = makeDocument(id: docId);
+      final pages = makePages(3, documentId: docId);
+      final ocrInput = MemoryOcrInput(Uint8List(4));
+      const ocrPageResult = OcrPageResult(rawText: 'hello', confidence: 0.8);
+
+      when(() => mockDocumentRepository.findById(docId))
+          .thenAnswer((_) async => doc);
+      when(() => mockDocumentRepository.update(any()))
+          .thenAnswer((inv) async => inv.positionalArguments.first as Document);
+      when(() => mockPageRepository.findByDocumentId(docId))
+          .thenAnswer((_) async => pages);
+      when(() => mockRenderer.renderPage(any(), any()))
+          .thenAnswer((_) async => ocrInput);
+      when(() => mockOcrEngine.extractText(any()))
+          .thenAnswer((_) async => ocrPageResult);
+      when(() => mockPageRepository.update(any())).thenAnswer((_) async {});
+
+      final result = await pipeline.runOcrForDocument(docId);
+
+      // Returned OcrResult is correct.
+      expect(result.documentId, docId);
+      expect(result.pageCount, 3);
+      expect(result.aggregateConfidence, closeTo(0.8, 1e-9));
+
+      // Status transitions: processing → completed.
+      final capturedDocs = verify(
+        () => mockDocumentRepository.update(captureAny()),
+      ).captured.cast<Document>();
+      expect(capturedDocs.length, 2);
+      expect(capturedDocs[0].status, DocumentStatus.processing);
+      expect(capturedDocs[1].status, DocumentStatus.completed);
+
+      // Every page was updated with rawText and ocrConfidence.
+      final capturedPages = verify(
+        () => mockPageRepository.update(captureAny()),
+      ).captured.cast<Page>();
+      expect(capturedPages.length, 3);
+      for (final p in capturedPages) {
+        expect(p.rawText, 'hello');
+        expect(p.ocrConfidence, 0.8);
+      }
+    });
   });
 }

--- a/test/application/document_pipeline_ocr_test.dart
+++ b/test/application/document_pipeline_ocr_test.dart
@@ -213,5 +213,36 @@ void main() {
         expect(p.ocrConfidence, 0.8);
       }
     });
+
+    // -------------------------------------------------------------------------
+    // FTS sync
+    // -------------------------------------------------------------------------
+
+    test('calls FTS sync exactly once with the document ID after all pages processed', () async {
+      const docId = 'doc-1';
+      final doc = makeDocument(id: docId);
+      final pages = makePages(3, documentId: docId);
+      final ocrInput = MemoryOcrInput(Uint8List(4));
+      const ocrPageResult = OcrPageResult(rawText: 'world', confidence: 0.9);
+
+      when(() => mockDocumentRepository.findById(docId))
+          .thenAnswer((_) async => doc);
+      when(() => mockDocumentRepository.update(any()))
+          .thenAnswer((inv) async => inv.positionalArguments.first as Document);
+      when(() => mockPageRepository.findByDocumentId(docId))
+          .thenAnswer((_) async => pages);
+      when(() => mockRenderer.renderPage(any(), any()))
+          .thenAnswer((_) async => ocrInput);
+      when(() => mockOcrEngine.extractText(any()))
+          .thenAnswer((_) async => ocrPageResult);
+      when(() => mockPageRepository.update(any())).thenAnswer((_) async {});
+
+      await pipeline.runOcrForDocument(docId);
+
+      // FTS sync must be called exactly once, after all pages are processed.
+      verify(() => mockSearchIndexSync.syncDocument(docId)).called(1);
+      // All 3 pages must have been updated before sync fires.
+      verify(() => mockPageRepository.update(any())).called(3);
+    });
   });
 }

--- a/test/application/document_pipeline_ocr_test.dart
+++ b/test/application/document_pipeline_ocr_test.dart
@@ -1,0 +1,116 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:personal_archive/src/application/document_pipeline_impl.dart';
+import 'package:personal_archive/src/application/import_validator.dart';
+import 'package:personal_archive/src/application/pdf_metadata_reader.dart';
+import 'package:personal_archive/src/application/pdf_page_image_renderer.dart';
+import 'package:personal_archive/src/application/search_index_sync.dart';
+import 'package:personal_archive/src/domain/document.dart';
+import 'package:personal_archive/src/domain/document_file_storage.dart';
+import 'package:personal_archive/src/domain/document_repository.dart';
+import 'package:personal_archive/src/domain/ocr_engine.dart';
+import 'package:personal_archive/src/domain/ocr_types.dart';
+import 'package:personal_archive/src/domain/page.dart';
+import 'package:personal_archive/src/domain/page_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Mocktail mocks
+// ---------------------------------------------------------------------------
+
+class MockImportValidator extends Mock implements ImportValidator {}
+
+class MockDocumentFileStorage extends Mock implements DocumentFileStorage {}
+
+class MockPdfMetadataReader extends Mock implements PdfMetadataReader {}
+
+class MockDocumentRepository extends Mock implements DocumentRepository {}
+
+class MockPageRepository extends Mock implements PageRepository {}
+
+class MockSearchIndexSync extends Mock implements SearchIndexSync {}
+
+class MockOCREngine extends Mock implements OCREngine {}
+
+class MockPdfPageImageRenderer extends Mock implements PdfPageImageRenderer {}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Document makeDocument({
+  String id = 'doc-1',
+  DocumentStatus status = DocumentStatus.imported,
+}) =>
+    Document(
+      id: id,
+      title: 'Test Document',
+      filePath: '/storage/doc-1.pdf',
+      status: status,
+      createdAt: DateTime.utc(2024),
+      updatedAt: DateTime.utc(2024),
+    );
+
+List<Page> makePages(int count, {String documentId = 'doc-1'}) =>
+    List.generate(
+      count,
+      (i) => Page(
+        id: 'page-${i + 1}',
+        documentId: documentId,
+        pageNumber: i + 1,
+      ),
+    );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('DocumentPipelineImpl.runOcrForDocument', () {
+    late DocumentPipelineImpl pipeline;
+    late MockImportValidator mockValidator;
+    late MockDocumentFileStorage mockFileStorage;
+    late MockPdfMetadataReader mockMetadataReader;
+    late MockDocumentRepository mockDocumentRepository;
+    late MockPageRepository mockPageRepository;
+    late MockSearchIndexSync mockSearchIndexSync;
+    late MockOCREngine mockOcrEngine;
+    late MockPdfPageImageRenderer mockRenderer;
+
+    setUp(() {
+      mockValidator = MockImportValidator();
+      mockFileStorage = MockDocumentFileStorage();
+      mockMetadataReader = MockPdfMetadataReader();
+      mockDocumentRepository = MockDocumentRepository();
+      mockPageRepository = MockPageRepository();
+      mockSearchIndexSync = MockSearchIndexSync();
+      mockOcrEngine = MockOCREngine();
+      mockRenderer = MockPdfPageImageRenderer();
+
+      // Default best-effort stub so individual tests need not repeat it.
+      when(() => mockSearchIndexSync.syncDocument(any()))
+          .thenAnswer((_) async {});
+
+      pipeline = DocumentPipelineImpl(
+        validator: mockValidator,
+        fileStorage: mockFileStorage,
+        metadataReader: mockMetadataReader,
+        documentRepository: mockDocumentRepository,
+        pageRepository: mockPageRepository,
+        searchIndexSync: mockSearchIndexSync,
+        renderer: mockRenderer,
+        ocrEngine: mockOcrEngine,
+      );
+
+      // Fallback values required by mocktail for any() / captureAny().
+      registerFallbackValue(makeDocument());
+      registerFallbackValue(
+        Page(id: 'fb', documentId: 'fb', pageNumber: 1),
+      );
+      registerFallbackValue(
+        MemoryOcrInput(Uint8List(0)),
+      );
+    });
+  });
+}

--- a/test/application/document_pipeline_ocr_test.dart
+++ b/test/application/document_pipeline_ocr_test.dart
@@ -13,6 +13,7 @@ import 'package:personal_archive/src/domain/document_repository.dart';
 import 'package:personal_archive/src/domain/ocr_engine.dart';
 import 'package:personal_archive/src/domain/ocr_types.dart';
 import 'package:personal_archive/src/domain/page.dart';
+import 'package:personal_archive/src/application/ocr_pipeline_errors.dart';
 import 'package:personal_archive/src/domain/page_repository.dart';
 
 // ---------------------------------------------------------------------------
@@ -111,6 +112,25 @@ void main() {
       registerFallbackValue(
         MemoryOcrInput(Uint8List(0)),
       );
+    });
+
+    // -------------------------------------------------------------------------
+    // Guard: document not found
+    // -------------------------------------------------------------------------
+
+    test('throws DocumentNotFoundError when document does not exist', () async {
+      when(() => mockDocumentRepository.findById(any()))
+          .thenAnswer((_) async => null);
+
+      await expectLater(
+        () => pipeline.runOcrForDocument('missing-id'),
+        throwsA(isA<DocumentNotFoundError>()),
+      );
+
+      verify(() => mockDocumentRepository.findById('missing-id')).called(1);
+      verifyNever(() => mockRenderer.renderPage(any(), any()));
+      verifyNever(() => mockOcrEngine.extractText(any()));
+      verifyNever(() => mockDocumentRepository.update(any()));
     });
   });
 }

--- a/test/application/document_pipeline_ocr_test.dart
+++ b/test/application/document_pipeline_ocr_test.dart
@@ -16,6 +16,7 @@ import 'package:personal_archive/src/domain/page.dart';
 import 'package:personal_archive/src/application/ocr_pipeline_errors.dart';
 import 'package:personal_archive/src/application/ocr_result.dart';
 import 'package:personal_archive/src/domain/ocr_error.dart';
+import 'package:personal_archive/src/domain/storage_error.dart';
 import 'package:personal_archive/src/application/pdf_page_image_renderer.dart'
     show PdfRenderError;
 import 'package:personal_archive/src/domain/page_repository.dart';
@@ -339,6 +340,46 @@ void main() {
 
       // OCR engine must never be reached.
       verifyNever(() => mockOcrEngine.extractText(any()));
+      verifyNever(() => mockSearchIndexSync.syncDocument(any()));
+    });
+
+    // -------------------------------------------------------------------------
+    // Storage failure
+    // -------------------------------------------------------------------------
+
+    test('sets document to failed and throws OcrStorageError when page update throws', () async {
+      const docId = 'doc-1';
+      final doc = makeDocument(id: docId);
+      final pages = makePages(2, documentId: docId);
+      final ocrInput = MemoryOcrInput(Uint8List(4));
+      const ocrPageResult = OcrPageResult(rawText: 'ok', confidence: 0.7);
+
+      when(() => mockDocumentRepository.findById(docId))
+          .thenAnswer((_) async => doc);
+      when(() => mockDocumentRepository.update(any()))
+          .thenAnswer((inv) async => inv.positionalArguments.first as Document);
+      when(() => mockPageRepository.findByDocumentId(docId))
+          .thenAnswer((_) async => pages);
+      when(() => mockRenderer.renderPage(any(), any()))
+          .thenAnswer((_) async => ocrInput);
+      when(() => mockOcrEngine.extractText(any()))
+          .thenAnswer((_) async => ocrPageResult);
+
+      // Page persistence throws on first write.
+      when(() => mockPageRepository.update(any()))
+          .thenThrow(const StorageUnknownError('disk full'));
+
+      await expectLater(
+        () => pipeline.runOcrForDocument(docId),
+        throwsA(isA<OcrStorageError>()),
+      );
+
+      // Document must be marked failed.
+      final capturedDocs = verify(
+        () => mockDocumentRepository.update(captureAny()),
+      ).captured.cast<Document>();
+      expect(capturedDocs.last.status, DocumentStatus.failed);
+
       verifyNever(() => mockSearchIndexSync.syncDocument(any()));
     });
   });

--- a/test/application/document_pipeline_ocr_test.dart
+++ b/test/application/document_pipeline_ocr_test.dart
@@ -16,6 +16,8 @@ import 'package:personal_archive/src/domain/page.dart';
 import 'package:personal_archive/src/application/ocr_pipeline_errors.dart';
 import 'package:personal_archive/src/application/ocr_result.dart';
 import 'package:personal_archive/src/domain/ocr_error.dart';
+import 'package:personal_archive/src/application/pdf_page_image_renderer.dart'
+    show PdfRenderError;
 import 'package:personal_archive/src/domain/page_repository.dart';
 
 // ---------------------------------------------------------------------------
@@ -295,6 +297,48 @@ void main() {
       expect(capturedDocs.last.status, DocumentStatus.failed);
 
       // FTS sync must NOT be called on failure.
+      verifyNever(() => mockSearchIndexSync.syncDocument(any()));
+    });
+
+    // -------------------------------------------------------------------------
+    // Render failure
+    // -------------------------------------------------------------------------
+
+    test('sets document to failed and throws OcrRenderError when renderer throws', () async {
+      const docId = 'doc-1';
+      final doc = makeDocument(id: docId);
+      final pages = makePages(2, documentId: docId);
+
+      when(() => mockDocumentRepository.findById(docId))
+          .thenAnswer((_) async => doc);
+      when(() => mockDocumentRepository.update(any()))
+          .thenAnswer((inv) async => inv.positionalArguments.first as Document);
+      when(() => mockPageRepository.findByDocumentId(docId))
+          .thenAnswer((_) async => pages);
+
+      // Renderer throws on first page.
+      when(() => mockRenderer.renderPage(any(), any()))
+          .thenThrow(const PdfRenderError('corrupt page'));
+
+      await expectLater(
+        () => pipeline.runOcrForDocument(docId),
+        throwsA(
+          isA<OcrRenderError>().having(
+            (e) => e.pageNumber,
+            'pageNumber',
+            1,
+          ),
+        ),
+      );
+
+      // Document must be marked failed.
+      final capturedDocs = verify(
+        () => mockDocumentRepository.update(captureAny()),
+      ).captured.cast<Document>();
+      expect(capturedDocs.last.status, DocumentStatus.failed);
+
+      // OCR engine must never be reached.
+      verifyNever(() => mockOcrEngine.extractText(any()));
       verifyNever(() => mockSearchIndexSync.syncDocument(any()));
     });
   });


### PR DESCRIPTION
## What

Unit test suite for `runOcrForDocument` in `DocumentPipelineImpl`. Covers every state transition and failure path without touching real OCR, PDF rendering, or a database.

## Why

The OCR pipeline stage had zero test coverage. Refactoring or changing error-handling logic had no safety net.

## Changes

Added `test/application/document_pipeline_ocr_test.dart` with 9 tests across 6 scenarios:

| Scenario | Asserts |
|---|---|
| Document not found | throws `DocumentNotFoundError`, engine never called |
| Invalid state (`processing`, `completed`, `failed`) | throws `InvalidDocumentStateError`, no status mutation |
| Success path (3 pages) | `processing → completed`, all pages updated with `rawText` + `ocrConfidence`, correct `OcrResult` |
| FTS sync | `syncDocument` called exactly once after all pages processed |
| OCR engine failure on page K | throws `OcrEnginePipelineError(pageNumber: K)`, status → `failed`, no FTS sync |
| Render failure | throws `OcrRenderError`, engine never reached, status → `failed` |
| Storage failure | throws `OcrStorageError`, status → `failed` |

All dependencies mocked with mocktail (`MockDocumentRepository`, `MockPageRepository`, `MockOCREngine`, `MockPdfPageImageRenderer`, `MockSearchIndexSync`).

## Testing

```
flutter test test/application/
# 20/20 passed
```

## Checklist

- [x] All AC from issue #10 covered
- [x] No real OCR, PDF renderer, or DB used
- [x] Linter passes
- [x] No debug logs or TODOs