### PR TITLE
Test/tintegration tests for ocr pipeline mock ocr

### DIFF
--- a/integration_test/helpers/mock_ocr_engine.dart
+++ b/integration_test/helpers/mock_ocr_engine.dart
@@ -1,0 +1,64 @@
+import 'package:personal_archive/src/domain/domain.dart';
+
+/// A per-page response entry for [MockOcrEngine].
+class MockOcrResponse {
+  const MockOcrResponse({required this.rawText, this.confidence});
+
+  final String rawText;
+  final double? confidence;
+}
+
+/// Test double for [OCREngine] that returns deterministic, injected
+/// [OcrPageResult]s per page index.
+///
+/// Usage:
+/// ```dart
+/// final engine = MockOcrEngine(pages: [
+///   MockOcrResponse(rawText: 'page one text', confidence: 0.95),
+///   MockOcrResponse(rawText: 'page two text', confidence: 0.90),
+/// ]);
+/// ```
+///
+/// Calls are matched by call-order: the first call to [extractText] returns
+/// [pages[0]], the second returns [pages[1]], etc.  If [throwOnPageIndex] is
+/// set, [extractText] throws an [OcrEngineError] when the call count reaches
+/// that index (0-based), simulating a mid-run OCR failure.
+class MockOcrEngine implements OCREngine {
+  MockOcrEngine({
+    required this.pages,
+    this.throwOnPageIndex,
+  });
+
+  /// Per-page deterministic responses, matched by call order.
+  final List<MockOcrResponse> pages;
+
+  /// If non-null, [extractText] throws [OcrEngineError] on this call index.
+  final int? throwOnPageIndex;
+
+  int _callCount = 0;
+
+  /// The responses that were actually consumed, in call order.
+  final List<MockOcrResponse> consumed = [];
+
+  @override
+  Future<OcrPageResult> extractText(OcrInput input) async {
+    final index = _callCount++;
+
+    if (throwOnPageIndex != null && index == throwOnPageIndex) {
+      throw OcrEngineError(
+        'MockOcrEngine: simulated failure on page index $index',
+      );
+    }
+
+    if (index >= pages.length) {
+      throw StateError(
+        'MockOcrEngine: no response configured for call index $index '
+        '(only ${pages.length} page(s) configured)',
+      );
+    }
+
+    final response = pages[index];
+    consumed.add(response);
+    return OcrPageResult(rawText: response.rawText, confidence: response.confidence);
+  }
+}

--- a/integration_test/helpers/mock_pdf_page_image_renderer.dart
+++ b/integration_test/helpers/mock_pdf_page_image_renderer.dart
@@ -3,6 +3,13 @@ import 'dart:typed_data' show Uint8List;
 import 'package:personal_archive/src/application/pdf_page_image_renderer.dart';
 import 'package:personal_archive/src/domain/ocr_types.dart';
 
+/// A recorded [renderPage] invocation.
+class RenderCall {
+  const RenderCall(this.pdfPath, this.pageNumber);
+  final String pdfPath;
+  final int pageNumber;
+}
+
 /// A minimal 1×1 white PNG used as the default [MemoryOcrInput] bytes.
 ///
 /// This is a valid PNG bytestream so it can be passed to any code that
@@ -37,12 +44,12 @@ class MockPdfPageImageRenderer implements PdfPageImageRenderer {
 
   final OcrInput _fixedInput;
 
-  /// All `(pdfPath, pageNumber)` pairs received, in call order.
-  final List<(String, int)> renderCalls = [];
+  /// All [RenderCall] records received, in call order.
+  final List<RenderCall> renderCalls = [];
 
   @override
   Future<OcrInput> renderPage(String pdfPath, int pageNumber) async {
-    renderCalls.add((pdfPath, pageNumber));
+    renderCalls.add(RenderCall(pdfPath, pageNumber));
     return _fixedInput;
   }
 }

--- a/integration_test/helpers/mock_pdf_page_image_renderer.dart
+++ b/integration_test/helpers/mock_pdf_page_image_renderer.dart
@@ -1,0 +1,48 @@
+import 'dart:typed_data' show Uint8List;
+
+import 'package:personal_archive/src/application/pdf_page_image_renderer.dart';
+import 'package:personal_archive/src/domain/ocr_types.dart';
+
+/// A minimal 1×1 white PNG used as the default [MemoryOcrInput] bytes.
+///
+/// This is a valid PNG bytestream so it can be passed to any code that
+/// inspects the image header, while keeping the test helper self-contained
+/// without any asset files.
+final Uint8List _kMinimalPng = Uint8List.fromList(const <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+  0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR chunk length + type
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // width=1, height=1
+  0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, // 8-bit RGB, CRC
+  0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, // IDAT chunk
+  0x54, 0x08, 0xD7, 0x63, 0xF8, 0xFF, 0xFF, 0x3F,
+  0x00, 0x05, 0xFE, 0x02, 0xFE, 0xDC, 0xCC, 0x59,
+  0xE7, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, // IEND chunk
+  0x44, 0xAE, 0x42, 0x60, 0x82,
+]);
+
+/// Test double for [PdfPageImageRenderer] that returns a fixed [OcrInput]
+/// for every page, decoupling OCR pipeline tests from real PDF rendering and
+/// platform image APIs.
+///
+/// By default, each call returns a [MemoryOcrInput] backed by [_kMinimalPng].
+/// Pass a custom [fixedInput] to control exactly what the OCR engine receives.
+///
+/// The [renderCalls] list records every `(pdfPath, pageNumber)` pair that was
+/// requested, enabling assertions about which pages the pipeline actually
+/// rendered.
+class MockPdfPageImageRenderer implements PdfPageImageRenderer {
+  MockPdfPageImageRenderer({OcrInput? fixedInput})
+      : _fixedInput = fixedInput ??
+            MemoryOcrInput(_kMinimalPng, width: 1, height: 1);
+
+  final OcrInput _fixedInput;
+
+  /// All `(pdfPath, pageNumber)` pairs received, in call order.
+  final List<(String, int)> renderCalls = [];
+
+  @override
+  Future<OcrInput> renderPage(String pdfPath, int pageNumber) async {
+    renderCalls.add((pdfPath, pageNumber));
+    return _fixedInput;
+  }
+}

--- a/integration_test/integration_test.dart
+++ b/integration_test/integration_test.dart
@@ -1,11 +1,13 @@
 import 'package:integration_test/integration_test.dart';
 
 import 'tests/import_pipeline_tests.dart' as import_pipeline;
+import 'tests/ocr_pipeline_tests.dart' as ocr_pipeline;
 import 'tests/pdf_metadata_reader_tests.dart' as pdf_metadata_reader;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   import_pipeline.main();
+  ocr_pipeline.main();
   pdf_metadata_reader.main();
 }

--- a/integration_test/tests/ocr_pipeline_tests.dart
+++ b/integration_test/tests/ocr_pipeline_tests.dart
@@ -182,7 +182,7 @@ void main() {
       (WidgetTester tester) async {
         // Arrange: embed a phrase that is unique to the mock OCR output so the
         // FTS query cannot accidentally match the document title or other content.
-        const uniquePhrase = 'fts-unique-ocr-phrase';
+        const uniquePhrase = 'fts_unique_ocr_phrase';
         const pageCount = 13;
         final ocrPipeline = buildPipeline(
           renderer: MockPdfPageImageRenderer(),

--- a/integration_test/tests/ocr_pipeline_tests.dart
+++ b/integration_test/tests/ocr_pipeline_tests.dart
@@ -133,7 +133,50 @@ void main() {
       },
     );
 
-    // TODO(commit-5): assert every page carries rawText and ocrConfidence from mock
+    testWidgets(
+      'every page has rawText and ocrConfidence matching mock output after OCR',
+      (WidgetTester tester) async {
+        // Arrange: deterministic per-page responses with distinct text and
+        // confidence values so any mix-up in ordering is immediately visible.
+        const pageCount = 13;
+        final responses = List.generate(
+          pageCount,
+          (i) => MockOcrResponse(
+            rawText: 'deterministic page ${i + 1} content',
+            confidence: 0.80 + i * 0.01,
+          ),
+        );
+
+        final ocrPipeline = buildPipeline(
+          renderer: MockPdfPageImageRenderer(),
+          ocrEngine: MockOcrEngine(pages: responses),
+        );
+
+        // Act.
+        await ocrPipeline.runOcrForDocument(importedDocumentId);
+
+        // Assert: fetch pages sorted by pageNumber so index == pageNumber - 1.
+        final pages = await pageRepo.findByDocumentId(importedDocumentId);
+        pages.sort((a, b) => a.pageNumber.compareTo(b.pageNumber));
+
+        expect(pages.length, pageCount);
+        for (var i = 0; i < pageCount; i++) {
+          final page = pages[i];
+          final expected = responses[i];
+          expect(
+            page.rawText,
+            expected.rawText,
+            reason: 'rawText mismatch on page ${i + 1}',
+          );
+          expect(
+            page.ocrConfidence,
+            closeTo(expected.confidence!, 1e-9),
+            reason: 'ocrConfidence mismatch on page ${i + 1}',
+          );
+        }
+      },
+    );
+
     // TODO(commit-6): assert FTS query surfaces document after OCR writes text
 
     // ── Failure-path tests (commit 7) ────────────────────────────────────

--- a/integration_test/tests/ocr_pipeline_tests.dart
+++ b/integration_test/tests/ocr_pipeline_tests.dart
@@ -177,7 +177,47 @@ void main() {
       },
     );
 
-    // TODO(commit-6): assert FTS query surfaces document after OCR writes text
+    testWidgets(
+      'FTS index contains mock OCR text and returns document after runOcrForDocument',
+      (WidgetTester tester) async {
+        // Arrange: embed a phrase that is unique to the mock OCR output so the
+        // FTS query cannot accidentally match the document title or other content.
+        const uniquePhrase = 'fts-unique-ocr-phrase';
+        const pageCount = 13;
+        final ocrPipeline = buildPipeline(
+          renderer: MockPdfPageImageRenderer(),
+          ocrEngine: MockOcrEngine(
+            pages: List.generate(
+              pageCount,
+              (i) => MockOcrResponse(
+                // Only the first page embeds the unique phrase; the rest are
+                // plain filler so the FTS match is unambiguous.
+                rawText: i == 0
+                    ? 'first page contains $uniquePhrase for search'
+                    : 'filler text for page ${i + 1}',
+                confidence: 0.95,
+              ),
+            ),
+          ),
+        );
+
+        // Act.
+        await ocrPipeline.runOcrForDocument(importedDocumentId);
+
+        // Assert: FTS table has a row for the document whose content contains
+        // the unique phrase.
+        final rows = db.select(
+          'SELECT document_id FROM documents_fts WHERE documents_fts MATCH ?',
+          [uniquePhrase],
+        );
+
+        expect(rows, isNotEmpty, reason: 'FTS index should contain the mock OCR phrase');
+        expect(
+          rows.map((r) => r['document_id']).toList(),
+          contains(importedDocumentId),
+        );
+      },
+    );
 
     // ── Failure-path tests (commit 7) ────────────────────────────────────
 

--- a/integration_test/tests/ocr_pipeline_tests.dart
+++ b/integration_test/tests/ocr_pipeline_tests.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+import 'package:personal_archive/infrastructure/file_storage/local_document_file_storage.dart';
+import 'package:personal_archive/infrastructure/pdf/pdf_metadata_reader_impl.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_document_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_fts_sync_service.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_page_repository.dart';
+import 'package:personal_archive/src/application/document_pipeline_impl.dart';
+import 'package:personal_archive/src/application/import_validator.dart';
+
+import '../helpers/mock_ocr_engine.dart';
+import '../helpers/mock_pdf_page_image_renderer.dart';
+import '../helpers/test_database.dart';
+import '../helpers/test_storage.dart';
+
+void main() {
+  late Directory storageDir;
+  late sqlite.Database db;
+  late MigrationDb migrationDb;
+
+  // Shared repository/service objects — rebuilt fresh for every test.
+  late SqliteDocumentRepository documentRepo;
+  late SqlitePageRepository pageRepo;
+  late SqliteFtsSyncService ftsSync;
+  late LocalDocumentFileStorage fileStorage;
+  late PdfMetadataReaderImpl metadataReader;
+
+  // The document id produced by the import step; available to every test.
+  late String importedDocumentId;
+
+  /// Builds a [DocumentPipelineImpl] wired to the shared repositories but
+  /// with per-test [renderer] and [ocrEngine] mocks.
+  ///
+  /// The import step in [setUp] uses stubs; each OCR test constructs its
+  /// own pipeline so the mock engines carry the correct per-test responses.
+  DocumentPipelineImpl buildPipeline({
+    required MockPdfPageImageRenderer renderer,
+    required MockOcrEngine ocrEngine,
+  }) {
+    return DocumentPipelineImpl(
+      validator: ImportValidator(pdfMetadataReader: metadataReader),
+      fileStorage: fileStorage,
+      metadataReader: metadataReader,
+      documentRepository: documentRepo,
+      pageRepository: pageRepo,
+      searchIndexSync: ftsSync,
+      renderer: renderer,
+      ocrEngine: ocrEngine,
+    );
+  }
+
+  group('OCR Pipeline Integration Tests', () {
+    setUp(() async {
+      // 1. Spin up a fresh in-memory SQLite DB with all migrations applied.
+      storageDir = await setupTestStorage();
+      final result = await setupTestDatabase();
+      db = result.db;
+      migrationDb = result.migrationDb;
+
+      // 2. Build repository and service objects backed by that DB.
+      documentRepo = SqliteDocumentRepository(migrationDb);
+      pageRepo = SqlitePageRepository(migrationDb);
+      ftsSync = SqliteFtsSyncService(migrationDb);
+      fileStorage = LocalDocumentFileStorage(storageDir.path);
+      metadataReader = PdfMetadataReaderImpl();
+
+      // 3. Run the import step with stub OCR dependencies so every test
+      //    starts from a document already in the `imported` state with
+      //    pages persisted in the DB and the PDF stored on disk.
+      final importPipeline = buildPipeline(
+        renderer: MockPdfPageImageRenderer(),
+        ocrEngine: MockOcrEngine(pages: const []),
+      );
+
+      final assetData =
+          await rootBundle.load('integration_test/assets/Example_PDF.pdf');
+      final inputFile =
+          File(p.join(storageDir.path, 'ocr_test_input.pdf'));
+      await inputFile.writeAsBytes(assetData.buffer.asUint8List());
+
+      final importResult = await importPipeline.importFromPath(inputFile.path);
+      importedDocumentId = importResult.document.id;
+    });
+
+    tearDown(() async {
+      await cleanupTestStorage(storageDir);
+      db.dispose();
+    });
+
+    // ── Happy-path tests (commits 4, 5, 6) ───────────────────────────────
+
+    // TODO(commit-4): assert document reaches `completed` after runOcrForDocument
+    // TODO(commit-5): assert every page carries rawText and ocrConfidence from mock
+    // TODO(commit-6): assert FTS query surfaces document after OCR writes text
+
+    // ── Failure-path tests (commit 7) ────────────────────────────────────
+
+    // TODO(commit-7): assert document transitions to `failed` when OCR throws mid-run
+  });
+}

--- a/integration_test/tests/ocr_pipeline_tests.dart
+++ b/integration_test/tests/ocr_pipeline_tests.dart
@@ -221,6 +221,59 @@ void main() {
 
     // ── Failure-path tests (commit 7) ────────────────────────────────────
 
-    // TODO(commit-7): assert document transitions to `failed` when OCR throws mid-run
+    testWidgets(
+      'document transitions to failed when OCR engine throws mid-run',
+      (WidgetTester tester) async {
+        // Arrange: engine succeeds on page 1 (index 0) but throws on page 2
+        // (index 1), simulating a partial OCR failure mid-document.
+        const pageCount = 13;
+        final ocrEngine = MockOcrEngine(
+          pages: List.generate(
+            pageCount,
+            (i) => MockOcrResponse(
+              rawText: 'page ${i + 1} text',
+              confidence: 0.90,
+            ),
+          ),
+          throwOnPageIndex: 1, // throw on the second extractText call
+        );
+
+        final ocrPipeline = buildPipeline(
+          renderer: MockPdfPageImageRenderer(),
+          ocrEngine: ocrEngine,
+        );
+
+        // Act: the pipeline must not let the OcrPipelineError escape uncaught;
+        // it should swallow it internally after marking the document as failed.
+        // We catch here in case the implementation re-throws (both are valid per
+        // the design — what matters is the persisted document state).
+        try {
+          await ocrPipeline.runOcrForDocument(importedDocumentId);
+        } catch (_) {
+          // Expected: OcrEnginePipelineError propagated after status update.
+        }
+
+        // Assert: document status is `failed` regardless of whether the error
+        // was re-thrown.
+        final savedDoc = await documentRepo.findById(importedDocumentId);
+        expect(savedDoc, isNotNull);
+        expect(
+          savedDoc!.status,
+          DocumentStatus.failed,
+          reason: 'document should be marked failed after OCR engine error',
+        );
+
+        // Assert: only page 1 (index 0) could have been processed before the
+        // throw; at most one page should have rawText set.
+        final pages = await pageRepo.findByDocumentId(importedDocumentId);
+        final pagesWithText =
+            pages.where((p) => p.rawText != null && p.rawText!.isNotEmpty);
+        expect(
+          pagesWithText.length,
+          lessThanOrEqualTo(1),
+          reason: 'at most the first page should have rawText after mid-run failure',
+        );
+      },
+    );
   });
 }

--- a/integration_test/tests/ocr_pipeline_tests.dart
+++ b/integration_test/tests/ocr_pipeline_tests.dart
@@ -13,6 +13,8 @@ import 'package:personal_archive/infrastructure/sqlite/sqlite_fts_sync_service.d
 import 'package:personal_archive/infrastructure/sqlite/sqlite_page_repository.dart';
 import 'package:personal_archive/src/application/document_pipeline_impl.dart';
 import 'package:personal_archive/src/application/import_validator.dart';
+import 'package:personal_archive/src/application/ocr_result.dart';
+import 'package:personal_archive/src/domain/document.dart';
 
 import '../helpers/mock_ocr_engine.dart';
 import '../helpers/mock_pdf_page_image_renderer.dart';
@@ -95,7 +97,42 @@ void main() {
 
     // ── Happy-path tests (commits 4, 5, 6) ───────────────────────────────
 
-    // TODO(commit-4): assert document reaches `completed` after runOcrForDocument
+    testWidgets(
+      'runOcrForDocument returns OcrResult and document reaches completed',
+      (WidgetTester tester) async {
+        // Arrange: one MockOcrResponse per page (test PDF has 13 pages).
+        const pageCount = 13;
+        final ocrEngine = MockOcrEngine(
+          pages: List.generate(
+            pageCount,
+            (i) => MockOcrResponse(
+              rawText: 'mock text for page ${i + 1}',
+              confidence: 0.90 + i * 0.001,
+            ),
+          ),
+        );
+
+        final ocrPipeline = buildPipeline(
+          renderer: MockPdfPageImageRenderer(),
+          ocrEngine: ocrEngine,
+        );
+
+        // Act.
+        final result = await ocrPipeline.runOcrForDocument(importedDocumentId);
+
+        // Assert: OcrResult shape.
+        expect(result, isA<OcrResult>());
+        expect(result.documentId, importedDocumentId);
+        expect(result.pageCount, pageCount);
+        expect(result.aggregateConfidence, isNotNull);
+
+        // Assert: persisted document status.
+        final savedDoc = await documentRepo.findById(importedDocumentId);
+        expect(savedDoc, isNotNull);
+        expect(savedDoc!.status, DocumentStatus.completed);
+      },
+    );
+
     // TODO(commit-5): assert every page carries rawText and ocrConfidence from mock
     // TODO(commit-6): assert FTS query surfaces document after OCR writes text
 


### PR DESCRIPTION
## What changed

Added integration tests for the OCR pipeline using mock dependencies, keeping tests platform-independent and fast.

**New files:**
- `integration_test/helpers/mock_ocr_engine.dart` — `MockOcrEngine` with per-page deterministic responses and configurable mid-run throw
- `integration_test/helpers/mock_pdf_page_image_renderer.dart` — `MockPdfPageImageRenderer` returning a fixed `OcrInput`, no platform PDF APIs needed

**New tests** (`integration_test/tests/ocr_pipeline_tests.dart`):
1. `runOcrForDocument` returns `OcrResult` and document reaches `completed`
2. Every page has `rawText` and `ocrConfidence` matching mock output
3. FTS index contains OCR text and surfaces the document by phrase
4. Document transitions to `failed` when OCR engine throws mid-run

Wired into `integration_test/integration_test.dart` alongside existing suites.

## Why it changed

The full OCR flow (repository wiring, FTS sync, pipeline orchestration) had no integration test coverage. These tests prove the real SQLite repositories, file storage, and pipeline impl work end-to-end without requiring a native OCR engine.

## How to test

```bash
flutter test integration_test/integration_test.dart -d macos --name "OCR Pipeline"
```

All 4 tests should pass. No device or simulator required.

## Checklist
- [x]  Tests added
- [x]  Documentation updated
- [x]  Linter/Formatter passes
- [x]  No debug logs left in code