### PR TITLE
Test/platform specific integration test with real ocr

### DIFF
--- a/.github/workflows/platform_ocr_integration.yml
+++ b/.github/workflows/platform_ocr_integration.yml
@@ -1,0 +1,66 @@
+# Runs the optional platform-specific OCR integration tests on the native OS
+# runners where the real OCR engine is available.
+#
+# These tests are intentionally NOT part of the default CI matrix: they
+# require native platform APIs (Apple Vision on macOS, WinRT on Windows) and
+# may be slower than the mock-based integration tests.  A failure here does
+# not block pull requests on other platforms.
+#
+# Trigger manually via workflow_dispatch, or add push/pull_request triggers
+# scoped to the paths that affect the OCR adapters when desired.
+
+name: Platform OCR Integration Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # macOS — Apple Vision OCR
+  # ---------------------------------------------------------------------------
+  macos-ocr:
+    name: Real OCR – macOS
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run macOS OCR integration test
+        run: |
+          flutter test integration_test \
+            --device-id macos \
+            --dart-define=RUN_PLATFORM_OCR=true
+
+  # ---------------------------------------------------------------------------
+  # Windows — WinRT Windows.Media.Ocr
+  # ---------------------------------------------------------------------------
+  windows-ocr:
+    name: Real OCR – Windows
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run Windows OCR integration test
+        run: |
+          flutter test integration_test `
+            --device-id windows `
+            --dart-define=RUN_PLATFORM_OCR=true

--- a/docs/integration_testing.md
+++ b/docs/integration_testing.md
@@ -43,3 +43,58 @@ Integration tests require real files to test the pipeline (e.g., PDF parsing).
 - **Location**: `integration_test/assets/`
 - **Configuration**: These assets are included in `pubspec.yaml` under the `flutter: assets:` section.
 - **Example**: `integration_test/assets/Example_PDF.pdf` (a small, valid PDF for happy-path testing).
+
+## Platform OCR Integration Tests (Real Engine)
+
+The test suites in `integration_test/tests/ocr_pipeline_real_macos_tests.dart`
+and `integration_test/tests/ocr_pipeline_real_windows_tests.dart` exercise the
+full pipeline with the **real** native OCR engine (Apple Vision on macOS, WinRT
+`Windows.Media.Ocr` on Windows). They are skipped automatically when run on any
+other platform, so they never block CI on Linux or in PR checks.
+
+### When to run them
+
+Run these tests manually before merging changes to the OCR adapters
+(`lib/infrastructure/ocr/ocr_engine_macos.dart` or
+`lib/infrastructure/ocr/ocr_engine_windows.dart`) or the PDF renderer.
+
+### Running locally
+
+On **macOS**:
+
+```bash
+flutter test integration_test -d macos
+```
+
+On **Windows** (PowerShell):
+
+```powershell
+flutter test integration_test -d windows
+```
+
+The platform guard (`integration_test/helpers/platform_guard.dart`) ensures
+that only the tests for the current OS are executed; the other platform's group
+is reported as skipped.
+
+### Running in CI
+
+A dedicated workflow at `.github/workflows/platform_ocr_integration.yml`
+targets `macos-latest` and `windows-latest` runners and is triggered manually
+via `workflow_dispatch`. It does not run on push or pull_request, so a failure
+here never blocks merging on other platforms.
+
+### What is asserted
+
+Both tests verify the same contract against their respective engine:
+
+1. The pipeline completes and the document reaches `DocumentStatus.completed`.
+2. At least one page has non-empty `rawText`.
+3. *(macOS only)* At least one page has a non-null `ocrConfidence` value —
+   Apple Vision always returns a confidence score; Windows.Media.Ocr does not.
+
+### Flakiness
+
+OCR output on real documents can vary slightly across OS versions or language
+pack configurations. If a test fails with an empty-text result on Windows,
+confirm that at least one OCR language pack is installed
+(`Settings → Time & Language → Language & Region`).

--- a/integration_test/helpers/platform_guard.dart
+++ b/integration_test/helpers/platform_guard.dart
@@ -1,0 +1,19 @@
+import 'dart:io' show Platform;
+
+/// Returns a skip-reason string when [condition] is `false`, and `null`
+/// (meaning "do not skip") when [condition] is `true`.
+///
+/// Pass the result directly to the `skip` parameter of [group] or [test]:
+///
+/// ```dart
+/// group(
+///   'real macOS OCR',
+///   skip: platformSkip(Platform.isMacOS, 'requires macOS'),
+///   () { … },
+/// );
+/// ```
+///
+/// This keeps platform-gate logic out of test bodies and makes the skip
+/// reason visible in test output on unsupported platforms.
+String? platformSkip(bool condition, String reason) =>
+    condition ? null : reason;

--- a/integration_test/integration_test.dart
+++ b/integration_test/integration_test.dart
@@ -2,6 +2,7 @@ import 'package:integration_test/integration_test.dart';
 
 import 'tests/import_pipeline_tests.dart' as import_pipeline;
 import 'tests/ocr_pipeline_tests.dart' as ocr_pipeline;
+import 'tests/ocr_pipeline_real_windows_tests.dart' as ocr_pipeline_real_windows;
 import 'tests/pdf_metadata_reader_tests.dart' as pdf_metadata_reader;
 
 void main() {
@@ -9,5 +10,6 @@ void main() {
 
   import_pipeline.main();
   ocr_pipeline.main();
+  ocr_pipeline_real_windows.main();
   pdf_metadata_reader.main();
 }

--- a/integration_test/integration_test.dart
+++ b/integration_test/integration_test.dart
@@ -2,6 +2,7 @@ import 'package:integration_test/integration_test.dart';
 
 import 'tests/import_pipeline_tests.dart' as import_pipeline;
 import 'tests/ocr_pipeline_tests.dart' as ocr_pipeline;
+import 'tests/ocr_pipeline_real_macos_tests.dart' as ocr_pipeline_real_macos;
 import 'tests/ocr_pipeline_real_windows_tests.dart' as ocr_pipeline_real_windows;
 import 'tests/pdf_metadata_reader_tests.dart' as pdf_metadata_reader;
 
@@ -11,5 +12,6 @@ void main() {
   import_pipeline.main();
   ocr_pipeline.main();
   ocr_pipeline_real_windows.main();
+  ocr_pipeline_real_macos.main();
   pdf_metadata_reader.main();
 }

--- a/integration_test/tests/ocr_pipeline_real_macos_tests.dart
+++ b/integration_test/tests/ocr_pipeline_real_macos_tests.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+import 'package:personal_archive/infrastructure/file_storage/local_document_file_storage.dart';
+import 'package:personal_archive/infrastructure/ocr/ocr_engine_macos.dart';
+import 'package:personal_archive/infrastructure/pdf/pdf_metadata_reader_impl.dart';
+import 'package:personal_archive/infrastructure/pdf/pdf_page_image_renderer_impl.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_document_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_fts_sync_service.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_page_repository.dart';
+import 'package:personal_archive/src/application/document_pipeline_impl.dart';
+import 'package:personal_archive/src/application/import_validator.dart';
+import 'package:personal_archive/src/domain/document.dart';
+
+import '../helpers/mock_ocr_engine.dart';
+import '../helpers/mock_pdf_page_image_renderer.dart';
+import '../helpers/platform_guard.dart';
+import '../helpers/test_database.dart';
+import '../helpers/test_storage.dart';
+
+void main() {
+  late Directory storageDir;
+  late sqlite.Database db;
+  late MigrationDb migrationDb;
+
+  late SqliteDocumentRepository documentRepo;
+  late SqlitePageRepository pageRepo;
+  late SqliteFtsSyncService ftsSync;
+  late LocalDocumentFileStorage fileStorage;
+  late PdfMetadataReaderImpl metadataReader;
+
+  late String importedDocumentId;
+
+  group(
+    'Real macOS OCR – platform integration',
+    skip: platformSkip(Platform.isMacOS, 'requires macOS'),
+    () {
+      setUp(() async {
+        storageDir = await setupTestStorage();
+        final result = await setupTestDatabase();
+        db = result.db;
+        migrationDb = result.migrationDb;
+
+        documentRepo = SqliteDocumentRepository(migrationDb);
+        pageRepo = SqlitePageRepository(migrationDb);
+        ftsSync = SqliteFtsSyncService(migrationDb);
+        fileStorage = LocalDocumentFileStorage(storageDir.path);
+        metadataReader = PdfMetadataReaderImpl();
+
+        // Import the shared test PDF using stub OCR so the document reaches
+        // the `imported` state ready for the real OCR step.
+        final importPipeline = DocumentPipelineImpl(
+          validator: ImportValidator(pdfMetadataReader: metadataReader),
+          fileStorage: fileStorage,
+          metadataReader: metadataReader,
+          documentRepository: documentRepo,
+          pageRepository: pageRepo,
+          searchIndexSync: ftsSync,
+          renderer: MockPdfPageImageRenderer(),
+          ocrEngine: MockOcrEngine(pages: const []),
+        );
+
+        final assetData =
+            await rootBundle.load('integration_test/assets/Example_PDF.pdf');
+        final inputFile =
+            File(p.join(storageDir.path, 'real_macos_ocr_input.pdf'));
+        await inputFile.writeAsBytes(assetData.buffer.asUint8List());
+
+        final importResult =
+            await importPipeline.importFromPath(inputFile.path);
+        importedDocumentId = importResult.document.id;
+      });
+
+      tearDown(() async {
+        await cleanupTestStorage(storageDir);
+        db.dispose();
+      });
+
+      testWidgets(
+        'runOcrForDocument with real MacOSOcrEngine: document reaches completed',
+        (WidgetTester tester) async {
+          // Arrange: wire the pipeline with real macOS OCR and real renderer.
+          final ocrPipeline = DocumentPipelineImpl(
+            validator: ImportValidator(pdfMetadataReader: metadataReader),
+            fileStorage: fileStorage,
+            metadataReader: metadataReader,
+            documentRepository: documentRepo,
+            pageRepository: pageRepo,
+            searchIndexSync: ftsSync,
+            renderer: PdfPageImageRendererImpl(),
+            ocrEngine: MacOSOcrEngine(),
+          );
+
+          // Act.
+          final result =
+              await ocrPipeline.runOcrForDocument(importedDocumentId);
+
+          // Assert: pipeline returned a coherent OcrResult.
+          expect(result.documentId, importedDocumentId);
+          expect(result.pageCount, greaterThan(0));
+
+          // Assert: document status updated to completed.
+          final savedDoc = await documentRepo.findById(importedDocumentId);
+          expect(savedDoc, isNotNull);
+          expect(savedDoc!.status, DocumentStatus.completed);
+
+          // Assert: at least one page has non-empty rawText.
+          final pages = await pageRepo.findByDocumentId(importedDocumentId);
+          final pagesWithText =
+              pages.where((pg) => pg.rawText != null && pg.rawText!.isNotEmpty);
+          expect(
+            pagesWithText,
+            isNotEmpty,
+            reason: 'real OCR should extract text from at least one page',
+          );
+
+          // Assert: ocrConfidence is present on pages that have text
+          // (Apple Vision always provides a confidence score).
+          final pagesWithConfidence = pagesWithText
+              .where((pg) => pg.ocrConfidence != null);
+          expect(
+            pagesWithConfidence,
+            isNotEmpty,
+            reason: 'Apple Vision should provide ocrConfidence for OCR pages',
+          );
+        },
+      );
+    },
+  );
+}

--- a/integration_test/tests/ocr_pipeline_real_windows_tests.dart
+++ b/integration_test/tests/ocr_pipeline_real_windows_tests.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+import 'package:personal_archive/infrastructure/file_storage/local_document_file_storage.dart';
+import 'package:personal_archive/infrastructure/ocr/ocr_engine_windows.dart';
+import 'package:personal_archive/infrastructure/pdf/pdf_metadata_reader_impl.dart';
+import 'package:personal_archive/infrastructure/pdf/pdf_page_image_renderer_impl.dart';
+import 'package:personal_archive/infrastructure/sqlite/migrations/migration_runner.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_document_repository.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_fts_sync_service.dart';
+import 'package:personal_archive/infrastructure/sqlite/sqlite_page_repository.dart';
+import 'package:personal_archive/src/application/document_pipeline_impl.dart';
+import 'package:personal_archive/src/application/import_validator.dart';
+import 'package:personal_archive/src/domain/document.dart';
+
+import '../helpers/mock_ocr_engine.dart';
+import '../helpers/mock_pdf_page_image_renderer.dart';
+import '../helpers/platform_guard.dart';
+import '../helpers/test_database.dart';
+import '../helpers/test_storage.dart';
+
+void main() {
+  late Directory storageDir;
+  late sqlite.Database db;
+  late MigrationDb migrationDb;
+
+  late SqliteDocumentRepository documentRepo;
+  late SqlitePageRepository pageRepo;
+  late SqliteFtsSyncService ftsSync;
+  late LocalDocumentFileStorage fileStorage;
+  late PdfMetadataReaderImpl metadataReader;
+
+  late String importedDocumentId;
+
+  group(
+    'Real Windows OCR – platform integration',
+    skip: platformSkip(Platform.isWindows, 'requires Windows'),
+    () {
+      setUp(() async {
+        storageDir = await setupTestStorage();
+        final result = await setupTestDatabase();
+        db = result.db;
+        migrationDb = result.migrationDb;
+
+        documentRepo = SqliteDocumentRepository(migrationDb);
+        pageRepo = SqlitePageRepository(migrationDb);
+        ftsSync = SqliteFtsSyncService(migrationDb);
+        fileStorage = LocalDocumentFileStorage(storageDir.path);
+        metadataReader = PdfMetadataReaderImpl();
+
+        // Import the shared test PDF using stub OCR so the document reaches
+        // the `imported` state ready for the real OCR step.
+        final importPipeline = DocumentPipelineImpl(
+          validator: ImportValidator(pdfMetadataReader: metadataReader),
+          fileStorage: fileStorage,
+          metadataReader: metadataReader,
+          documentRepository: documentRepo,
+          pageRepository: pageRepo,
+          searchIndexSync: ftsSync,
+          renderer: MockPdfPageImageRenderer(),
+          ocrEngine: MockOcrEngine(pages: const []),
+        );
+
+        final assetData =
+            await rootBundle.load('integration_test/assets/Example_PDF.pdf');
+        final inputFile =
+            File(p.join(storageDir.path, 'real_windows_ocr_input.pdf'));
+        await inputFile.writeAsBytes(assetData.buffer.asUint8List());
+
+        final importResult =
+            await importPipeline.importFromPath(inputFile.path);
+        importedDocumentId = importResult.document.id;
+      });
+
+      tearDown(() async {
+        await cleanupTestStorage(storageDir);
+        db.dispose();
+      });
+
+      testWidgets(
+        'runOcrForDocument with real WindowsOcrEngine: document reaches completed',
+        (WidgetTester tester) async {
+          // Arrange: wire the pipeline with real Windows OCR and real renderer.
+          final ocrPipeline = DocumentPipelineImpl(
+            validator: ImportValidator(pdfMetadataReader: metadataReader),
+            fileStorage: fileStorage,
+            metadataReader: metadataReader,
+            documentRepository: documentRepo,
+            pageRepository: pageRepo,
+            searchIndexSync: ftsSync,
+            renderer: PdfPageImageRendererImpl(),
+            ocrEngine: WindowsOcrEngine(),
+          );
+
+          // Act.
+          final result =
+              await ocrPipeline.runOcrForDocument(importedDocumentId);
+
+          // Assert: pipeline returned a coherent OcrResult.
+          expect(result.documentId, importedDocumentId);
+          expect(result.pageCount, greaterThan(0));
+
+          // Assert: document status updated to completed.
+          final savedDoc = await documentRepo.findById(importedDocumentId);
+          expect(savedDoc, isNotNull);
+          expect(savedDoc!.status, DocumentStatus.completed);
+
+          // Assert: at least one page has non-empty rawText.
+          final pages = await pageRepo.findByDocumentId(importedDocumentId);
+          final pagesWithText =
+              pages.where((pg) => pg.rawText != null && pg.rawText!.isNotEmpty);
+          expect(
+            pagesWithText,
+            isNotEmpty,
+            reason: 'real OCR should extract text from at least one page',
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## What changed

Added optional platform-specific integration tests that run the full OCR pipeline with the **real** native engine — Apple Vision on macOS, WinRT `Windows.Media.Ocr` on Windows.

- `integration_test/helpers/platform_guard.dart` — tiny helper that returns a skip reason when the current OS doesn't match, keeping platform guards out of test bodies
- `integration_test/tests/ocr_pipeline_real_macos_tests.dart` — imports → real `PdfPageImageRendererImpl` + `MacOSOcrEngine` → asserts `completed` status, non-empty `rawText`, and non-null `ocrConfidence` on at least one page
- `integration_test/tests/ocr_pipeline_real_windows_tests.dart` — same contract with `WindowsOcrEngine`; no confidence assertion (WinRT doesn't expose one)
- `.github/workflows/platform_ocr_integration.yml` — `workflow_dispatch`-only workflow, macOS and Windows jobs isolated to their matching runner; never runs automatically, so it can't block CI on Linux
- `docs/integration_testing.md` — new section explaining when/how to run, what is asserted, CI setup, and the Windows language-pack flakiness caveat

## Why it changed

The macOS and Windows OCR adapters had unit tests with a mocked channel but no end-to-end coverage with the real OS APIs. This gap made it easy to break the native layer (Swift/C++ ↔ Dart channel contract) without any test catching it. Closes issue #12.

## How to test

**macOS** (runs real OCR, skips Windows group):
```bash
flutter test integration_test -d macos
```
**Windows** (runs real OCR, skips macOS group):
```bash
flutter test integration_test -d windows
```

## Checklist

- [x]  Tests added
- [x]  Documentation updated ([integration_testing.md]
- [x]  No debug logs or TODOs left in code
- [x]  Linter/Formatter passesChecklist
 
