### PR TITLE
Docs/intelligence adrs and high level decisions 2

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,3 +130,13 @@ For Phase 2 PDF import implementation details and decisions, see:
 * `decisions/0012-file-storage-strategy-for-imported-pdfs.md`
 * `decisions/0013-pdf-library-choice-for-metadata.md`
 
+For Phase 4 Intelligence and local LLM behavior, see:
+
+* `intelligence_overview.md`
+* `llm_integration.md`
+* `decisions/0003-use-llama-cpp-for-local-llm.md`
+* `decisions/0017-processed-text-storage-for-intelligence.md`
+* `decisions/0018-chunking-strategy-and-token-budget.md`
+* `decisions/0019-llm-default-configuration-for-intelligence.md`
+* `decisions/0020-intelligence-pipeline-behavior-and-partial-results.md`
+

--- a/docs/decisions/0017-processed-text-storage-for-intelligence.md
+++ b/docs/decisions/0017-processed-text-storage-for-intelligence.md
@@ -1,0 +1,48 @@
+# Processed text storage for Intelligence (per-page, document-level aggregation)
+
+Date: 2026-02-25
+
+Status: Accepted
+
+## Context
+
+Phase 4 (Intelligence) introduces multiple LLM-backed analyses (summaries, keywords, places, future classifiers) that operate on cleaned, normalized text rather than raw OCR output.
+
+The existing schema already includes:
+
+- `pages.processed_text` (per-page cleaned text).
+- A document-level FTS index (`documents_fts`) that concatenates page text (see `storage_conventions.md` § 7 and ADR 0011).
+- A document-level `summaries` table and optional `embeddings` table.
+
+We need to clarify whether processed text is a **per-page concept**, a **per-document concept**, or both, and how this interacts with FTS and future Intelligence features.
+
+## Decision
+
+- **Primary unit of processed text is the page:**
+  - `pages.processed_text` remains the canonical home for cleaned text.
+  - All Intelligence pipelines that need cleaned text read from `pages.processed_text` (falling back to `pages.raw_text` only when necessary).
+- **Document-level aggregation is derived, not stored as a separate canonical field:**
+  - When needed, the application concatenates `pages.processed_text` in `page_number` order to form a document-level text view.
+  - The `documents_fts` table continues to index **aggregated page text**, summaries, and keywords, without introducing a new “processed document text” column in the `documents` table.
+- **Schema changes for Phase 4 are minimal:**
+  - No new core tables are added for processed text.
+  - If auxiliary cache columns or materialized views are introduced later for performance, they are treated as **derived data**, not new sources of truth.
+
+## Consequences
+
+- **Pros**
+  - + Keeps the schema simple and aligned with existing Phase 1/2 decisions.
+  - + Preserves per-page traceability for debugging and targeted reprocessing.
+  - + Avoids duplicating large processed text blobs at both page and document levels.
+  - + Integrates cleanly with existing FTS design (document-level indexing derived from page-level text).
+
+- **Cons / Trade-offs**
+  - - Some Intelligence operations that conceptually work on “the whole document” must stream or aggregate page text on the fly.
+  - - Large documents may require careful batching when concatenating text for LLM input.
+
+- **Implications for future work**
+  - Any new Phase 4 repositories or services that need “document text” should depend on:
+    - `pages.processed_text` as the canonical source, and
+    - a **document-text view helper** that aggregates per-page text in a predictable order.
+  - If per-section or per-chunk storage is introduced later (e.g., for re-usable semantic chunks), those will layer on top of `pages.processed_text` rather than replacing it.
+

--- a/docs/decisions/0018-chunking-strategy-and-token-budget.md
+++ b/docs/decisions/0018-chunking-strategy-and-token-budget.md
@@ -6,7 +6,7 @@ Status: Accepted
 
 ## Context
 
-Phase 4 Intelligence features (summarization, keyword extraction, place detection, future classifiers) run on a local Qwen 2.5 0.5B model via llama.cpp (see ADR 0003).
+Phase 4 Intelligence features (summarization, keyword extraction, place detection, future classifiers) run on a local Qwen 3 0.6B model via llama.cpp (see ADR 0003).
 
 We need a **chunking strategy and token budget** that:
 
@@ -19,7 +19,7 @@ This ADR defines **how we split text into LLM chunks** and how much of the conte
 ## Decision
 
 - **Target context usage**
-  - Assume a conservative **effective context window of ~4,096 tokens** for Qwen 2.5 0.5B in our local configuration.
+  - Assume a conservative **effective context window of ~4,096 tokens** for Qwen 3 0.6B in our local configuration.
   - Reserve **~25% of the window for system/user prompts and model output**, leaving **~3,000 tokens** for document content per request.
 
 - **Chunk size**

--- a/docs/decisions/0018-chunking-strategy-and-token-budget.md
+++ b/docs/decisions/0018-chunking-strategy-and-token-budget.md
@@ -1,0 +1,58 @@
+# Chunking strategy and token budget for Intelligence
+
+Date: 2026-02-25
+
+Status: Accepted
+
+## Context
+
+Phase 4 Intelligence features (summarization, keyword extraction, place detection, future classifiers) run on a local Qwen 2.5 0.5B model via llama.cpp (see ADR 0003).
+
+We need a **chunking strategy and token budget** that:
+
+- Fits comfortably within the model’s context window.
+- Balances quality (enough surrounding context) and performance (latency, CPU, memory).
+- Works consistently across different Intelligence tasks and large documents.
+
+This ADR defines **how we split text into LLM chunks** and how much of the context window we reserve for prompts vs. document content.
+
+## Decision
+
+- **Target context usage**
+  - Assume a conservative **effective context window of ~4,096 tokens** for Qwen 2.5 0.5B in our local configuration.
+  - Reserve **~25% of the window for system/user prompts and model output**, leaving **~3,000 tokens** for document content per request.
+
+- **Chunk size**
+  - Target **1,000–1,500 tokens of document text per chunk**.
+  - This leaves headroom for:
+    - Prompt scaffolding (instructions, examples).
+    - Model output (summaries, keyword lists, classifications).
+
+- **Chunk boundaries**
+  - Chunking operates on **processed text** derived from `pages.processed_text` (see ADR 0017).
+  - Prefer **semantic boundaries** in this order:
+    1. Explicit paragraph breaks (double newlines or similar markers).
+    2. Sentence boundaries (when paragraph sizes are uneven or too large).
+    3. As a fallback, fixed token windows with small overlaps.
+  - Allow **small overlaps** (e.g., 5–10% of chunk size) between neighboring chunks to preserve continuity, especially for summarization.
+
+- **Pipeline integration**
+  - Each Intelligence stage that works on “document text” processes **one chunk at a time**.
+  - Per-document results (e.g., a single summary) are derived by **combining per-chunk outputs** according to stage-specific rules (e.g., summarize-each-chunk then summarize-the-summaries).
+
+## Consequences
+
+- **Pros**
+  - + Keeps each request safely within the context window for the chosen local model.
+  - + Reasonable latency and memory footprint on typical local machines.
+  - + Works uniformly across Intelligence features and large documents.
+
+- **Cons / Trade-offs**
+  - - Summaries and keyword sets are influenced by chunk boundaries; global context is approximated via multi-step aggregation.
+  - - Very large documents require multiple passes (more API calls, more total compute).
+
+- **Implications for future tuning**
+  - The numeric thresholds (4,096 effective context, 1,000–1,500 token chunk size, overlap percentage) are **configuration defaults**, not hard-coded magic numbers:
+    - They should be exposed via configuration for tuning per environment.
+    - Any change to default chunk sizes or reserved prompt budget should be validated against performance and quality benchmarks and, if significant, recorded as an update to this ADR or a superseding ADR.
+

--- a/docs/decisions/0019-llm-default-configuration-for-intelligence.md
+++ b/docs/decisions/0019-llm-default-configuration-for-intelligence.md
@@ -1,0 +1,66 @@
+# LLM default configuration for Intelligence (Qwen 2.5 0.5B via llama.cpp)
+
+Date: 2026-02-25
+
+Status: Accepted
+
+## Context
+
+ADR 0003 decided to use **Qwen 3.0 0.6B** running locally via **llama.cpp** as the Intelligence model for summarization, keyword extraction, place detection, and future classification tasks.
+
+To keep behavior predictable and reproducible across environments, we need a **default configuration** for:
+
+- Model variant (GGUF file),
+- Context window,
+- Quantization,
+- Core sampling parameters.
+
+These defaults should be:
+
+- Safe for typical local hardware (CPU + RAM).
+- Tunable via configuration without changing code.
+- Stable enough that other docs and tests can assume them.
+
+## Decision
+
+- **Model variant**
+  - Default to a **Qwen 3 0.6B Instruct GGUF** model suitable for CPU-only inference.
+  - The concrete GGUF filename and download location are configured in the application configuration (not hard-coded in code).
+
+- **Context window**
+  - Configure llama.cpp with an **effective context window of 4,096 tokens** for Phase 4.
+  - Intelligence services should treat this as the **maximum budget**, with chunking rules from ADR 0018 ensuring we do not exceed it.
+
+- **Quantization**
+  - Use a **medium-aggressive quantization** preset (e.g., `Q4_K`-class) that:
+    - Fits comfortably in RAM on typical developer machines.
+    - Keeps latency acceptable for interactive use.
+  - The exact quantization level is specified in configuration (e.g., model filename), and can be overridden per environment.
+
+- **Sampling parameters (defaults)**
+  - Temperature: **0.3–0.5** (low to medium; favors determinism with slight variability).
+  - Top-p: **0.9**.
+  - Top-k: **40**.
+  - Repeat penalty: **1.1–1.2** (to reduce repetition in long generations).
+  - Maximum output tokens:
+    - Summaries: **up to ~512 tokens**.
+    - Keyword/label outputs: **up to ~256 tokens**.
+  - These values are defined as **configurable defaults** in the LLM service; tasks may override them when justified (e.g., shorter outputs for classification).
+
+## Consequences
+
+- **Pros**
+  - + Predictable behavior across environments and runs.
+  - + Reasonable performance on local hardware without requiring a GPU.
+  - + Shared defaults simplify pipeline configuration and testing.
+
+- **Cons / Trade-offs**
+  - - Conservative context and quantization choices may limit maximum quality compared to larger or less-quantized models.
+  - - Some tasks might benefit from more diversity or higher temperature and will need explicit overrides.
+
+- **Implications for future iterations**
+  - Changes to the **default model size, quantization, or context window** should trigger:
+    - Performance and quality benchmarking.
+    - A follow-up ADR if the change is substantial (e.g., moving to a larger model or a very different quantization).
+  - Task-specific overrides must remain within the global limits of the configured context window and sampling constraints and should be documented near the task-specific code and/or in future ADRs if they represent a broad policy shift.
+

--- a/docs/decisions/0020-intelligence-pipeline-behavior-and-partial-results.md
+++ b/docs/decisions/0020-intelligence-pipeline-behavior-and-partial-results.md
@@ -1,0 +1,70 @@
+# Intelligence pipeline behavior: partial results and re-runs
+
+Date: 2026-02-25
+
+Status: Accepted
+
+## Context
+
+ADR 0006 established a **pipeline-driven processing** model for import, OCR, and downstream tasks.
+
+Phase 4 extends this with Intelligence stages such as:
+
+- Summarization,
+- Keyword extraction,
+- Place suggestion/detection,
+- Future classification/annotation stages.
+
+We need clear rules for:
+
+- How the pipeline behaves when some Intelligence stages succeed and others fail.
+- How **partial results** are stored and surfaced.
+- How **re-runs** work (idempotency, overwriting vs. appending).
+
+These rules must keep the system observable and predictable without locking us into brittle all-or-nothing behavior.
+
+## Decision
+
+- **Stage-level independence with explicit status**
+  - Intelligence stages are modeled as **independent steps** within the overall pipeline (continuing the spirit of ADR 0006).
+  - Each stage has its own success/failure semantics and can complete even if others fail.
+  - The document’s overall `status` remains aligned with the existing enum:
+    - `completed` means: all **required** Intelligence stages have either:
+      - succeeded, or
+      - been explicitly skipped/disabled by configuration.
+    - Non-required/optional stages may fail without forcing the document out of `completed`, but their failure is still logged and visible.
+
+- **Partial results policy**
+  - If a stage produces output (e.g., summary, keywords) and reports success:
+    - The output is **persisted** (e.g., in `summaries`, `document_keywords`, or a stage-specific table).
+    - Other failing stages do **not** invalidate already stored results.
+  - UI and APIs must be able to indicate **which Intelligence stages have data** and which failed or are pending.
+
+- **Re-run semantics**
+  - Re-running Intelligence for a document is **idempotent at the stage level**:
+    - By default, a re-run of a stage **overwrites** its previous outputs for that document (e.g., new summary replaces old summary, keyword relations are recalculated).
+    - Historical results and logs (e.g., timestamps, model versions) are preserved as metadata where stored (e.g., `model_version`, `created_at` columns) to maintain auditability.
+  - Re-runs may be triggered:
+    - Automatically for failed stages (retry policies).
+    - Manually, via user actions (e.g., “re-run Intelligence” on a document).
+  - The re-run policy is **per stage**:
+    - A stage can be selectively re-run without forcing all stages to re-execute.
+
+## Consequences
+
+- **Pros**
+  - + Robust to intermittent failures: successful stages do not get rolled back unnecessarily.
+  - + Clear user-facing behavior: partial results are visible and explainable.
+  - + Supports iterative improvements: re-running Intelligence after model, prompt, or configuration changes is straightforward.
+
+- **Cons / Trade-offs**
+  - - Overwriting stage outputs on re-run means we do not keep multiple historical versions of summaries/keywords by default (beyond timestamps and model version metadata).
+  - - UI and API layers must handle and display per-stage status, which is more complex than a single “done/not-done” flag.
+
+- **Implications for future work**
+  - Any new Intelligence stage must:
+    - Fit into this **stage-level independent** model.
+    - Define what counts as “required” vs “optional” for document `completed` status.
+    - Persist outputs in a way that supports overwrite-on-re-run with clear metadata (timestamps, model version, source).
+  - If future requirements demand full version history of Intelligence outputs, a dedicated versioning/mutation log can be introduced in a separate ADR, building on these baseline semantics.
+

--- a/docs/intelligence_overview.md
+++ b/docs/intelligence_overview.md
@@ -1,0 +1,140 @@
+# Intelligence Overview
+
+This document connects the core architecture (`architecture.md`), the document pipeline (`pipeline.md`), and the Intelligence-specific Architecture Decision Records for Phase 4. It explains how local LLM-based features fit into the system without breaking the existing design principles.
+
+---
+
+## Role of Intelligence in the Architecture
+
+Intelligence features (summaries, keywords, place suggestions, and future classifiers) live primarily in:
+
+- The **application layer**: orchestrating when and how Intelligence stages run in the pipeline.
+- The **domain layer**: defining contracts like `LLMService`, `KeywordExtractor`, `PlaceClassifier`, and value objects for summaries, keywords, and predictions.
+- The **infrastructure layer**: providing concrete implementations backed by SQLite, llama.cpp, and platform-native OCR.
+
+This preserves the Clean Architecture boundaries defined in `architecture.md`: the UI only observes results and triggers pipeline actions; it never talks directly to the LLM or the database.
+
+Key baseline decisions:
+
+- **Local LLM via llama.cpp** – ADR `0003-use-llama-cpp-for-local-llm.md`
+- **Pipeline-driven processing** – ADR `0006-pipeline-driven-processing.md`
+- **SQLite FTS5 design** – ADR `0011-sqlite-fts5-design.md`
+
+Phase 4 builds Intelligence on top of these, rather than introducing a separate “AI sidecar” architecture.
+
+---
+
+## Processed Text and Storage Strategy
+
+Intelligence operates on **cleaned, per-page text**:
+
+- `pages.processed_text` is the canonical source for cleaned text.
+- Document-level text views are **derived** by concatenating `pages.processed_text` in `page_number` order when needed.
+- The FTS table `documents_fts` continues to index aggregated text from pages, summaries, and keywords (see `storage_conventions.md` and ADR 0011).
+
+This is captured in:
+
+- **ADR `0017-processed-text-storage-for-intelligence.md`**
+
+Implications:
+
+- Intelligence stages that need “the document text” must depend on:
+  - `pages.processed_text` as their input source, and
+  - a helper that aggregates page text deterministically.
+- We avoid duplicating big “processed document text” blobs in multiple places and retain per-page traceability for debugging and reprocessing.
+
+---
+
+## Chunking and Token Budget
+
+To run reliably on a local Qwen 2.5 0.5B model, Phase 4 defines a conservative chunking strategy:
+
+- Effective context window: **~4,096 tokens** (for the configured GGUF model).
+- Reserved budget:
+  - ~25% of the window is reserved for prompts and output.
+  - ~3,000 tokens are available for document content per request.
+- Chunk size:
+  - Target **1,000–1,500 tokens of document text per chunk**.
+  - Use semantic boundaries where possible (paragraphs, then sentences), with small overlaps between chunks for continuity.
+
+This is captured in:
+
+- **ADR `0018-chunking-strategy-and-token-budget.md`**
+
+In the pipeline (`pipeline.md`):
+
+- Text processing and LLM analysis stages operate **one chunk at a time**.
+- Per-document Intelligence results (e.g., a single summary) are assembled from chunk-level outputs using deterministic application-layer logic.
+
+---
+
+## LLM Defaults and Runtime Configuration
+
+Intelligence relies on a predictable, configurable local LLM runtime:
+
+- Model: **Qwen 2.5 0.5B Instruct GGUF** via llama.cpp.
+- Context window: configured for **4,096 tokens**.
+- Quantization: a medium-aggressive preset (e.g., Q4-class) tuned for CPU-only environments.
+- Sampling defaults:
+  - Temperature: **0.3–0.5**
+  - Top-p: **0.9**
+  - Top-k: **40**
+  - Repeat penalty: **1.1–1.2**
+  - Output limits: ~512 tokens for summaries, ~256 for keyword/label outputs.
+
+These defaults are defined in:
+
+- **ADR `0019-llm-default-configuration-for-intelligence.md`**
+
+Configuration principles (consistent with `architecture.md` and `storage_conventions.md`):
+
+- Model path, quantization variant, and sampling parameters are **externalized configuration**, not hard-coded.
+- Task-specific overrides (e.g., shorter outputs for classification) stay within the global context limit and are documented near their use.
+
+---
+
+## Pipeline Behavior, Partial Results, and Re-runs
+
+Intelligence extends the pipeline principles in `pipeline.md` and ADR 0006:
+
+- Each Intelligence stage (summary, keywords, place suggestion, embeddings, etc.) is a **separate, testable step**.
+- Stages are allowed to succeed or fail **independently**.
+- Partial results are **persisted** and remain visible even if other stages fail.
+
+This behavior is formalized in:
+
+- **ADR `0020-intelligence-pipeline-behavior-and-partial-results.md`**
+
+Key policies:
+
+- **Document status vs. per-stage status**
+  - `documents.status` still tracks high-level progress (`imported`, `processing`, `completed`, `failed`).
+  - Intelligence stages internally track their own success/failure; optional stages may fail without forcing the document out of `completed`, but failures are logged and visible.
+
+- **Re-runs**
+  - Re-running Intelligence is **stage-level idempotent by default**:
+    - A re-run overwrites prior outputs for that stage (e.g., summary text or document-keyword relations), while preserving timestamps and model version metadata.
+  - Re-runs can target:
+    - Failed stages (automatic or manual retry).
+    - Specific stages the user wants to regenerate (e.g., “re-run analysis” from the UI).
+
+This aligns with the broader pipeline principles:
+
+- Atomic, deterministic steps.
+- Observable, traceable behavior.
+- Replaceable components in both domain and infrastructure layers.
+
+---
+
+## How to Use This Document
+
+When designing or reviewing Phase 4 features, use this document as the entry point:
+
+- For **high-level architecture** and layer boundaries, read `architecture.md`.
+- For **end-to-end flow**, read `pipeline.md`.
+- For **Intelligence-specific behavior and defaults**, start here and then:
+  - Follow links to ADRs `0003`, `0006`, `0011`, `0017–0020`.
+  - Cross-check schema expectations in `data_model.md` and `storage_conventions.md`.
+
+Together, these documents describe how local-first Intelligence is integrated into the system without compromising the original architectural goals.
+

--- a/docs/llm_integration.md
+++ b/docs/llm_integration.md
@@ -1,0 +1,152 @@
+# Local LLM Integration (Qwen 2.5 via llama.cpp)
+
+This document summarizes how the local Qwen 2.5 (0.5B) model is integrated into the application without exposing implementation details or code. It connects the internal integration plan from `.preparation/llm_integration.md` with the public architecture described in:
+
+- `architecture.md`
+- `pipeline.md`
+- `intelligence_overview.md`
+- ADRs `0003`, `0017–0020`
+
+The goal is to explain how the LLM fits into the system from a **design and behavior** perspective rather than as a step‑by‑step build guide.
+
+---
+
+## High-Level Runtime Architecture
+
+To keep the UI responsive and follow the Clean Architecture boundaries:
+
+- **Inference runs in a dedicated isolate**:
+  - Heavy work (model loading, token generation) happens in a background isolate.
+  - Communication with the main isolate (UI layer) uses message passing (ports), which allows streaming partial results (e.g., tokens or text chunks) back to the UI.
+- **LLM access is encapsulated behind domain/application interfaces**:
+  - The domain defines contracts such as `LLMService` and higher-level services for summarization and extraction.
+  - The concrete implementation in the infrastructure layer is responsible for:
+    - Managing the native llama.cpp runtime.
+    - Owning the model context and configuration.
+    - Translating domain requests into low-level inference calls and back.
+
+This ensures that:
+
+- The UI never calls native code directly.
+- The rest of the system remains testable with mocks and stubbed LLM implementations.
+
+---
+
+## Native Engine Integration (llama.cpp via FFI)
+
+The project uses `llama.cpp` as the underlying inference engine:
+
+- **Shared native library**:
+  - On each supported platform (Windows, macOS), llama.cpp is built as a shared library and bundled with the application.
+  - The shared library exposes a C API defined in `llama.h`.
+- **Generated bindings**:
+  - Dart FFI bindings are generated from the `llama.h` header using a binding generator (e.g., `ffigen`), producing a strongly typed Dart interface for the native functions.
+  - These bindings are used only within the infrastructure layer.
+- **Boundary responsibilities**:
+  - The FFI boundary is thin and mechanical: it forwards calls like model initialization, tokenization, decoding, and sampling.
+  - All higher-level logic (prompts, chunking, task orchestration) lives in Dart, above the FFI layer, and is described in `intelligence_overview.md` and the relevant ADRs.
+
+From the perspective of the rest of the application, llama.cpp is simply a local engine that implements the `LLMService` contract.
+
+---
+
+## Model Distribution and Lifecycle
+
+The Qwen 2.5 0.5B Instruct model is distributed as a **GGUF file**:
+
+- **First-run model acquisition**:
+  - On first use, the application ensures the configured GGUF model file is present in an application-specific directory (e.g., under `Application Support`).
+  - If the file is missing, the application can download it from a configured location (for example, a public model hosting provider), honoring the project’s local-first principle by:
+    - Making this download explicit to the user.
+    - Allowing offline operation once the model is present.
+- **Subsequent runs**:
+  - Subsequent launches reuse the existing on-disk model file.
+  - The model path and version are controlled via configuration, not hard-coded.
+
+Model lifecycle management aligns with ADR `0019-llm-default-configuration-for-intelligence.md`:
+
+- The runtime configures:
+  - Context window (e.g., 4,096 tokens).
+  - Quantization preset (e.g., a Q4‑class GGUF variant).
+  - Default sampling parameters (temperature, top‑p, top‑k, repeat penalty, output limits).
+- Intelligence services and pipelines use these defaults by default but may request task-specific overrides within the allowed limits.
+
+---
+
+## Inference Flow and Prompting (Conceptual)
+
+At a high level, every LLM call follows the same conceptual cycle:
+
+1. **Prompt construction**
+   - The application formats input into the model’s expected chat or instruction format (e.g., a ChatML-style prompt for Qwen).
+   - This includes both the **system-style instructions** (e.g., “you are a summarization model…”) and the **user content** (document text, chunk, or summary-of-summaries).
+2. **Tokenization and context preparation**
+   - Text is converted into token IDs understood by the model.
+   - The pipeline respects the chunking and token budget rules from ADR `0018`, ensuring each request fits inside the configured context window.
+3. **Decode–sample loop**
+   - The engine repeatedly:
+     - Processes the current tokens,
+     - Produces logits (next-token probabilities),
+     - Samples the next token based on configured sampling parameters.
+   - Partial outputs can be streamed back to the UI or collected into a complete response.
+4. **Post-processing**
+   - The raw LLM output is interpreted according to the task:
+     - Parsed as plain text for summaries.
+     - Parsed into lists or structured fields for keywords and labels.
+   - The domain layer then validates and persists results via repositories.
+
+This process is applied consistently across summarization, keyword extraction, and future classification tasks, with only the prompts and expected output formats changing.
+
+---
+
+## Deployment Considerations (Windows and macOS)
+
+The integration is designed to be **platform-aware but behaviorally identical** on Windows and macOS:
+
+- The llama.cpp shared library is:
+  - Bundled with the desktop application.
+  - Loaded dynamically at runtime via FFI.
+- Platform-specific packaging steps (e.g., build scripts, CMake configuration, or Xcode project settings) ensure that:
+  - The shared library is present in the final application bundle.
+  - Any required runtime permissions (such as network access for initial model download) are correctly configured.
+
+These concerns are isolated to the build and deployment pipeline and do not affect domain or application logic.
+
+---
+
+## Performance and Resource Strategy
+
+Performance and resource usage are managed in coordination with the Intelligence ADRs:
+
+- **Context size and chunking**
+  - Effective context window and chunk sizes are defined in ADR `0018-chunking-strategy-and-token-budget.md`.
+  - The integration ensures that LLM calls honor these budgets to avoid excessive memory usage or degraded performance.
+- **Quantization and model size**
+  - Quantization choices (e.g., Q4 vs Q8) are guided by ADR `0019-llm-default-configuration-for-intelligence.md`, balancing:
+    - Model quality,
+    - RAM footprint,
+    - Latency on typical local machines.
+- **Concurrency and isolates**
+  - Running inference in a dedicated isolate prevents UI freezes and allows controlled concurrency.
+  - The system can limit the number of concurrent requests to avoid oversubscribing CPU and memory.
+
+These strategies support the broader performance and observability goals described in `architecture.md` and `pipeline.md`.
+
+---
+
+## How This Fits with Other Documentation
+
+Use this document together with:
+
+- `intelligence_overview.md` for a functional view of what Intelligence does.
+- `architecture.md` for layer boundaries and design principles.
+- `pipeline.md` for the end-to-end document flow.
+- ADRs `0003`, `0017–0020` for detailed design decisions about:
+  - Local LLM choice and runtime,
+  - Processed text storage,
+  - Chunking and token budgets,
+  - Default LLM configuration,
+  - Pipeline behavior for partial results and re-runs.
+
+Taken together, these documents explain **how** the local LLM is integrated and **why** it behaves the way it does, without exposing private implementation details.
+

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -14,6 +14,16 @@ Every document flows through a deterministic pipeline that ensures:
 
 For Phase 2 PDF import implementation details (objectives, scope, storage, validation, interfaces, and cleanup semantics), see `pdf_import_pipeline.md`.
 
+For Phase 4 Intelligence behavior and LLM integration, see:
+
+- `intelligence_overview.md`
+- `llm_integration.md`
+- `decisions/0003-use-llama-cpp-for-local-llm.md`
+- `decisions/0017-processed-text-storage-for-intelligence.md`
+- `decisions/0018-chunking-strategy-and-token-budget.md`
+- `decisions/0019-llm-default-configuration-for-intelligence.md`
+- `decisions/0020-intelligence-pipeline-behavior-and-partial-results.md`
+
 The pipeline follows this sequence:
 
 
@@ -151,6 +161,8 @@ The pipeline follows this sequence:
 **Notes:**
 
 * LLM runtime is managed by `LLMRuntime` to ensure proper memory usage and concurrency.
+* For high-level Intelligence behavior and configuration, see `intelligence_overview.md` and ADRs `0018`, `0019`, `0020`.
+* For runtime integration details, see `llm_integration.md` and ADR `0003`.
 
 ---
 
@@ -267,6 +279,8 @@ Stored as placeId in the document entity.
 3. **Observable:** Logs, timing, confidence scores, and errors are recorded.
 4. **Isolated Failures:** Failures in one stage do not corrupt other stages; retry is possible.
 5. **Replaceable Components:** OCR, LLM, and text processors can be swapped without touching domain logic.
+
+For an Intelligence-focused view of these principles and how they apply to chunking, partial results, and re-runs, see `intelligence_overview.md` and ADR `0020-intelligence-pipeline-behavior-and-partial-results.md`.
 
 ---
 


### PR DESCRIPTION
## What changed

- Added Phase 4 Intelligence documentation (`intelligence_overview.md`, `llm_integration.md`) describing how local LLM-based features fit into the existing architecture and pipeline.
- Introduced new ADRs for Intelligence: processed text storage (0017), chunking and token budget (0018), LLM default configuration (0019), and pipeline behavior for partial results and re-runs (0020).
- Linked these new docs and ADRs from `architecture.md` and `pipeline.md` so Intelligence is discoverable from the core documentation.

## Why it changed

- To document the architectural decisions behind the Intelligence milestone (v0.3) and make the local LLM integration, runtime behavior, and pipeline semantics explicit and reviewable.
- To ensure future work on summarization, keyword extraction, and classification has clear, stable design references instead of relying on ad-hoc notes.

## How to test

1. Open `docs/architecture.md` and `docs/pipeline.md` and verify links to the new Intelligence docs and ADRs are present and correct.
2. Read `docs/intelligence_overview.md` and `docs/llm_integration.md` to confirm they align with the existing architecture and pipeline descriptions.
3. Skim ADRs `0017`–`0020` to check that naming, structure, and tone match the existing ADR set.

## Checklist

- [x] Tests added/updated (N/A – docs-only change)
- [x] Documentation updated (architecture, pipeline, ADRs)
- [x] Linter/Formatter passes (for markdown, if applicable)
- [x] No debug logs or TODOs left in code