### PR TITLE
Feat/text processing service processed text persistence

### DIFF
--- a/lib/src/application/application.dart
+++ b/lib/src/application/application.dart
@@ -6,3 +6,4 @@ export 'pdf_metadata_reader.dart';
 export 'pdf_page_image_renderer.dart';
 export 'search_index_sync.dart';
 export 'text_processing_service.dart';
+export 'text_processing_service_impl.dart';

--- a/lib/src/application/application.dart
+++ b/lib/src/application/application.dart
@@ -5,3 +5,4 @@ export 'paragraph_chunker.dart';
 export 'pdf_metadata_reader.dart';
 export 'pdf_page_image_renderer.dart';
 export 'search_index_sync.dart';
+export 'text_processing_service.dart';

--- a/lib/src/application/text_processing_errors.dart
+++ b/lib/src/application/text_processing_errors.dart
@@ -1,0 +1,57 @@
+/// Base class for errors occurring during the text processing stage.
+///
+/// All typed text processing errors extend this class, allowing callers to
+/// catch any text-processing-specific failure and distinguish it from
+/// unrelated exceptions. Each subtype carries a human-readable [message] and
+/// an optional [cause] for wrapping lower-level errors.
+abstract class TextProcessingError implements Exception {
+  const TextProcessingError();
+
+  /// A human-readable description of the failure.
+  String get message;
+
+  /// The underlying error that caused this failure, if any.
+  Object? get cause => null;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer('$runtimeType: $message');
+    if (cause != null) {
+      buffer.write(' (Cause: $cause)');
+    }
+    return buffer.toString();
+  }
+}
+
+/// The document has no pages; text processing cannot proceed.
+///
+/// This error is thrown before any processing begins when
+/// [PageRepository.findByDocumentId] returns an empty list, ensuring the
+/// caller receives a clear signal rather than a silent no-op.
+class DocumentHasNoPagesError extends TextProcessingError {
+  const DocumentHasNoPagesError(this.documentId);
+
+  /// The ID of the document that has no associated pages.
+  final String documentId;
+
+  @override
+  String get message => 'Document has no pages: $documentId';
+}
+
+/// A storage operation failed while persisting processed text.
+class TextProcessingStorageError extends TextProcessingError {
+  const TextProcessingStorageError({
+    required this.documentId,
+    required Object this.cause,
+  });
+
+  /// The ID of the document being processed when the error occurred.
+  final String documentId;
+
+  @override
+  final Object cause;
+
+  @override
+  String get message =>
+      'Storage failure while processing document $documentId';
+}

--- a/lib/src/application/text_processing_service.dart
+++ b/lib/src/application/text_processing_service.dart
@@ -1,0 +1,27 @@
+import 'text_processing_errors.dart';
+
+export 'text_processing_errors.dart';
+
+/// Contract for applying text cleaning to all pages of a document and
+/// persisting the result as [Page.processedText].
+///
+/// Implementations must:
+/// - Load all pages for the given [documentId] via [PageRepository].
+/// - Run [TextProcessor.clean] on each page's `rawText`.
+/// - Persist the cleaned text back to storage (single field update only).
+/// - Be **idempotent**: re-running the service on a document that has already
+///   been processed must not change the stored data or throw an error.
+///
+/// ### Behaviour for edge cases
+/// | Situation | Behaviour |
+/// |-----------|-----------|
+/// | Document has no pages | Throws [DocumentHasNoPagesError] immediately. |
+/// | Page has null `rawText` | Page is silently skipped; `processedText` is left unchanged. |
+/// | Page already has `processedText` | Page is skipped; storage is not written again. |
+abstract class TextProcessingService {
+  /// Processes all eligible pages of the document identified by [documentId].
+  ///
+  /// Throws [DocumentHasNoPagesError] when the document has no pages.
+  /// Throws [TextProcessingStorageError] when a persistence operation fails.
+  Future<void> processDocument(String documentId);
+}

--- a/lib/src/application/text_processing_service_impl.dart
+++ b/lib/src/application/text_processing_service_impl.dart
@@ -1,0 +1,43 @@
+import '../domain/page_repository.dart';
+import '../domain/storage_error.dart';
+import '../domain/text_processor.dart';
+import 'text_processing_errors.dart';
+import 'text_processing_service.dart';
+
+/// Concrete implementation of [TextProcessingService].
+///
+/// Loads pages via [PageRepository], cleans each page's `rawText` with
+/// [TextProcessor], and persists the result back as `processedText`.
+///
+/// This class has no dependency on UI or Flutter; it can be used from a
+/// background isolate, a pipeline step, or a test without any additional setup.
+class TextProcessingServiceImpl implements TextProcessingService {
+  const TextProcessingServiceImpl({
+    required this.pageRepository,
+    required this.textProcessor,
+  });
+
+  final PageRepository pageRepository;
+  final TextProcessor textProcessor;
+
+  @override
+  Future<void> processDocument(String documentId) async {
+    final pages = await pageRepository.findByDocumentId(documentId);
+
+    for (final page in pages) {
+      final raw = page.rawText;
+      if (raw == null) continue;
+
+      final cleaned = textProcessor.clean(raw);
+      final updated = page.copyWith(processedText: cleaned);
+
+      try {
+        await pageRepository.update(updated);
+      } on StorageError catch (e) {
+        throw TextProcessingStorageError(documentId: documentId, cause: e);
+      } catch (e) {
+        throw TextProcessingStorageError(documentId: documentId, cause: e);
+      }
+    }
+  }
+}

--- a/lib/src/application/text_processing_service_impl.dart
+++ b/lib/src/application/text_processing_service_impl.dart
@@ -24,6 +24,10 @@ class TextProcessingServiceImpl implements TextProcessingService {
   Future<void> processDocument(String documentId) async {
     final pages = await pageRepository.findByDocumentId(documentId);
 
+    if (pages.isEmpty) {
+      throw DocumentHasNoPagesError(documentId);
+    }
+
     for (final page in pages) {
       final raw = page.rawText;
       if (raw == null) continue;

--- a/lib/src/application/text_processing_service_impl.dart
+++ b/lib/src/application/text_processing_service_impl.dart
@@ -15,6 +15,11 @@ import 'text_processing_service.dart';
 /// a partially OCR-processed document should not block text processing for
 /// the pages that do have text.
 ///
+/// ### Idempotency
+/// Pages that already have a non-null `processedText` are skipped without
+/// issuing a storage write. Re-running the service on a fully processed
+/// document is therefore a safe no-op.
+///
 /// This class has no dependency on UI or Flutter; it can be used from a
 /// background isolate, a pipeline step, or a test without any additional setup.
 class TextProcessingServiceImpl implements TextProcessingService {
@@ -40,6 +45,10 @@ class TextProcessingServiceImpl implements TextProcessingService {
       // is left as-is (null) so a subsequent run can pick them up once OCR
       // completes.
       if (raw == null) continue;
+
+      // Idempotency: skip pages that have already been processed so that
+      // re-running the service does not issue redundant storage writes.
+      if (page.processedText != null) continue;
 
       final cleaned = textProcessor.clean(raw);
       final updated = page.copyWith(processedText: cleaned);

--- a/lib/src/application/text_processing_service_impl.dart
+++ b/lib/src/application/text_processing_service_impl.dart
@@ -9,6 +9,12 @@ import 'text_processing_service.dart';
 /// Loads pages via [PageRepository], cleans each page's `rawText` with
 /// [TextProcessor], and persists the result back as `processedText`.
 ///
+/// ### Pages with absent rawText
+/// Pages whose `rawText` is `null` are silently skipped. Their `processedText`
+/// is left untouched and no storage write is issued. This is intentional:
+/// a partially OCR-processed document should not block text processing for
+/// the pages that do have text.
+///
 /// This class has no dependency on UI or Flutter; it can be used from a
 /// background isolate, a pipeline step, or a test without any additional setup.
 class TextProcessingServiceImpl implements TextProcessingService {
@@ -30,6 +36,9 @@ class TextProcessingServiceImpl implements TextProcessingService {
 
     for (final page in pages) {
       final raw = page.rawText;
+      // Skip pages that have not yet been through OCR; their processedText
+      // is left as-is (null) so a subsequent run can pick them up once OCR
+      // completes.
       if (raw == null) continue;
 
       final cleaned = textProcessor.clean(raw);

--- a/lib/src/service_locator.dart
+++ b/lib/src/service_locator.dart
@@ -2,6 +2,7 @@ import 'package:personal_archive/infrastructure/pdf/pdf_metadata_reader_impl.dar
 import 'package:personal_archive/infrastructure/pdf/pdf_page_image_renderer_impl.dart';
 import 'package:personal_archive/src/application/application.dart';
 import 'package:personal_archive/src/domain/ocr_config.dart';
+import 'package:personal_archive/src/domain/page_repository.dart';
 
 /// Simple service locator for dependency injection.
 ///
@@ -15,6 +16,8 @@ class ServiceLocator {
   PdfMetadataReader? _pdfMetadataReader;
   PdfPageImageRenderer? _pdfPageImageRenderer;
   ImportValidator? _importValidator;
+  PageRepository? _pageRepository;
+  TextProcessingService? _textProcessingService;
   OcrConfig _ocrConfig = const OcrConfig();
 
   /// Returns the registered [PdfMetadataReader] implementation.
@@ -63,11 +66,49 @@ class ServiceLocator {
     _importValidator = validator;
   }
 
+  /// Returns the registered [PageRepository] implementation.
+  ///
+  /// Must be set via the setter before first access; no default implementation
+  /// can be created without a database handle.
+  PageRepository get pageRepository {
+    assert(
+      _pageRepository != null,
+      'PageRepository has not been registered. '
+      'Call ServiceLocator.instance.pageRepository = ... before use.',
+    );
+    return _pageRepository!;
+  }
+
+  /// Overrides the [PageRepository] instance.
+  set pageRepository(PageRepository repository) {
+    _pageRepository = repository;
+    _textProcessingService = null; // force re-creation with new repository
+  }
+
+  /// Returns the registered [TextProcessingService] implementation.
+  ///
+  /// Lazily constructed from [pageRepository] and [OcrTextProcessor] on first
+  /// access. Override via the setter to supply a custom implementation
+  /// (e.g. in tests).
+  TextProcessingService get textProcessingService {
+    return _textProcessingService ??= TextProcessingServiceImpl(
+      pageRepository: pageRepository,
+      textProcessor: const OcrTextProcessor(),
+    );
+  }
+
+  /// Overrides the [TextProcessingService] instance (useful for testing).
+  set textProcessingService(TextProcessingService service) {
+    _textProcessingService = service;
+  }
+
   /// Resets all registrations. Intended for test teardown only.
   void reset() {
     _pdfMetadataReader = null;
     _pdfPageImageRenderer = null;
     _importValidator = null;
+    _pageRepository = null;
+    _textProcessingService = null;
     _ocrConfig = const OcrConfig();
   }
 }

--- a/test/application/text_processing_service_test.dart
+++ b/test/application/text_processing_service_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_archive/src/application/text_processing_service_impl.dart';
+import 'package:personal_archive/src/application/text_processing_errors.dart';
+import 'package:personal_archive/src/domain/page.dart';
+import 'package:personal_archive/src/domain/page_repository.dart';
+import 'package:personal_archive/src/domain/text_processor.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+/// In-memory [PageRepository] that records every [update] call.
+class _FakePageRepository implements PageRepository {
+  _FakePageRepository(List<Page> pages) : _store = {for (final p in pages) p.id: p};
+
+  final Map<String, Page> _store;
+  final List<Page> updatedPages = [];
+
+  @override
+  Future<List<Page>> findByDocumentId(String documentId) async =>
+      _store.values.where((p) => p.documentId == documentId).toList()
+        ..sort((a, b) => a.pageNumber.compareTo(b.pageNumber));
+
+  @override
+  Future<void> update(Page page) async {
+    _store[page.id] = page;
+    updatedPages.add(page);
+  }
+
+  @override
+  Future<void> insertAll(List<Page> pages) async {
+    for (final p in pages) {
+      _store[p.id] = p;
+    }
+  }
+}
+
+/// [TextProcessor] that prefixes cleaned text with 'cleaned:' for easy
+/// assertion without pulling in the real OCR processing logic.
+class _PrefixTextProcessor implements TextProcessor {
+  const _PrefixTextProcessor();
+
+  @override
+  String clean(String raw) => 'cleaned:$raw';
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Page _page({
+  required String id,
+  required String documentId,
+  required int pageNumber,
+  String? rawText,
+  String? processedText,
+}) =>
+    Page(
+      id: id,
+      documentId: documentId,
+      pageNumber: pageNumber,
+      rawText: rawText,
+      processedText: processedText,
+    );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  const processor = _PrefixTextProcessor();
+  const docId = 'doc-1';
+
+  group('TextProcessingServiceImpl – happy path', () {
+    test('populates processedText for all pages with rawText', () async {
+      final pages = [
+        _page(id: 'p1', documentId: docId, pageNumber: 1, rawText: 'raw one'),
+        _page(id: 'p2', documentId: docId, pageNumber: 2, rawText: 'raw two'),
+        _page(id: 'p3', documentId: docId, pageNumber: 3, rawText: 'raw three'),
+      ];
+      final repo = _FakePageRepository(pages);
+      final service = TextProcessingServiceImpl(
+        pageRepository: repo,
+        textProcessor: processor,
+      );
+
+      await service.processDocument(docId);
+
+      final updated = await repo.findByDocumentId(docId);
+      expect(updated[0].processedText, 'cleaned:raw one');
+      expect(updated[1].processedText, 'cleaned:raw two');
+      expect(updated[2].processedText, 'cleaned:raw three');
+    });
+
+    test('calls update once per page', () async {
+      final pages = [
+        _page(id: 'p1', documentId: docId, pageNumber: 1, rawText: 'a'),
+        _page(id: 'p2', documentId: docId, pageNumber: 2, rawText: 'b'),
+      ];
+      final repo = _FakePageRepository(pages);
+      final service = TextProcessingServiceImpl(
+        pageRepository: repo,
+        textProcessor: processor,
+      );
+
+      await service.processDocument(docId);
+
+      expect(repo.updatedPages, hasLength(2));
+    });
+
+    test('throws DocumentHasNoPagesError for a document with no pages', () async {
+      final repo = _FakePageRepository([]);
+      final service = TextProcessingServiceImpl(
+        pageRepository: repo,
+        textProcessor: processor,
+      );
+
+      await expectLater(
+        () => service.processDocument(docId),
+        throwsA(isA<DocumentHasNoPagesError>()),
+      );
+    });
+
+    test('skips pages whose rawText is null', () async {
+      final pages = [
+        _page(id: 'p1', documentId: docId, pageNumber: 1, rawText: 'text'),
+        _page(id: 'p2', documentId: docId, pageNumber: 2, rawText: null),
+      ];
+      final repo = _FakePageRepository(pages);
+      final service = TextProcessingServiceImpl(
+        pageRepository: repo,
+        textProcessor: processor,
+      );
+
+      await service.processDocument(docId);
+
+      final updated = await repo.findByDocumentId(docId);
+      expect(updated[0].processedText, 'cleaned:text');
+      expect(updated[1].processedText, isNull);
+      // Only one update should have been issued – for the page with rawText.
+      expect(repo.updatedPages, hasLength(1));
+    });
+  });
+}

--- a/test/application/text_processing_service_test.dart
+++ b/test/application/text_processing_service_test.dart
@@ -141,4 +141,52 @@ void main() {
       expect(repo.updatedPages, hasLength(1));
     });
   });
+
+  group('TextProcessingServiceImpl – idempotency', () {
+    test('processedText is unchanged after a second run', () async {
+      final pages = [
+        _page(id: 'p1', documentId: docId, pageNumber: 1, rawText: 'raw one'),
+        _page(id: 'p2', documentId: docId, pageNumber: 2, rawText: 'raw two'),
+      ];
+      final repo = _FakePageRepository(pages);
+      final service = TextProcessingServiceImpl(
+        pageRepository: repo,
+        textProcessor: processor,
+      );
+
+      await service.processDocument(docId);
+      final afterFirst = (await repo.findByDocumentId(docId))
+          .map((p) => p.processedText)
+          .toList();
+
+      await service.processDocument(docId);
+      final afterSecond = (await repo.findByDocumentId(docId))
+          .map((p) => p.processedText)
+          .toList();
+
+      expect(afterSecond, equals(afterFirst));
+    });
+
+    test('does not call update for already-processed pages on second run',
+        () async {
+      final pages = [
+        _page(id: 'p1', documentId: docId, pageNumber: 1, rawText: 'raw one'),
+        _page(id: 'p2', documentId: docId, pageNumber: 2, rawText: 'raw two'),
+      ];
+      final repo = _FakePageRepository(pages);
+      final service = TextProcessingServiceImpl(
+        pageRepository: repo,
+        textProcessor: processor,
+      );
+
+      await service.processDocument(docId);
+      final updatesAfterFirst = repo.updatedPages.length;
+
+      await service.processDocument(docId);
+      final updatesAfterSecond = repo.updatedPages.length;
+
+      // No additional updates should have been issued on the second run.
+      expect(updatesAfterSecond, equals(updatesAfterFirst));
+    });
+  });
 }


### PR DESCRIPTION
## What changed

Introduces `TextProcessingService` — an application-layer service that cleans OCR output and persists the result as `Page.processedText`.

- `TextProcessingService` (abstract) + `TextProcessingErrors` sealed hierarchy
- `TextProcessingServiceImpl`: loads pages, runs `TextProcessor.clean`, writes back via `PageRepository.update`
- Guards: fails fast on empty document, skips pages with no `rawText`, skips already-processed pages (idempotent)
- `ServiceLocator` wired with `pageRepository` and a lazily-constructed `textProcessingService`

## Why it changed

OCR-complete documents had `rawText` populated but nothing downstream could consume it. This closes that gap and gives the Intelligence pipeline a stable `processedText` source of truth to build on.

## How to test
```bash
flutter test
```

Six unit tests cover: happy path (all pages cleaned), no-pages fast-fail, null-`rawText` skip, and idempotency (no extra writes on re-run).

## Checklist

- [x] Tests added/updated
- [x] No debug logs or TODOs left in code
- [x] Documentation updated (ADR not required — behaviour documented in dartdoc)
- [x] Linter/Formatter passes
